### PR TITLE
Fix Issue Missing create events on OS X #14 && Clean Path

### DIFF
--- a/fsnotify_bsd.go
+++ b/fsnotify_bsd.go
@@ -114,6 +114,7 @@ func (w *Watcher) Close() error {
 // addWatch adds path to the watched file set.
 // The flags are interpreted as described in kevent(2).
 func (w *Watcher) addWatch(path string, flags uint32) error {
+	path = filepath.Clean(path)
 	w.mu.Lock()
 	if w.isClosed {
 		w.mu.Unlock()
@@ -216,6 +217,7 @@ func (w *Watcher) Add(name string) error {
 
 // Remove stops watching the the named file or directory (non-recursively).
 func (w *Watcher) Remove(name string) error {
+	name = filepath.Clean(name)
 	w.wmut.Lock()
 	watchfd, ok := w.watches[name]
 	w.wmut.Unlock()

--- a/fsnotify_linux.go
+++ b/fsnotify_linux.go
@@ -97,6 +97,7 @@ func (w *Watcher) Close() error {
 
 // Add starts watching the named file or directory (non-recursively).
 func (w *Watcher) Add(name string) error {
+	name = filepath.Clean(name)
 	if w.isClosed {
 		return errors.New("inotify instance already closed")
 	}
@@ -125,6 +126,7 @@ func (w *Watcher) Add(name string) error {
 
 // Remove stops watching the the named file or directory (non-recursively).
 func (w *Watcher) Remove(name string) error {
+	name = filepath.Clean(name)
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	watch, ok := w.watches[name]


### PR DESCRIPTION
fix Issue #14:  dirty but it works
Clean Path: Unify the format of Watcher.watches key on Linux and BSD
