### PR TITLE
global: switch to x/sys/unix

### DIFF
--- a/inotify.go
+++ b/inotify.go
@@ -14,7 +14,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
-	"syscall"
+	"golang.org/x/sys/unix"
 	"unsafe"
 )
 
@@ -35,14 +35,14 @@ type Watcher struct {
 // NewWatcher establishes a new watcher with the underlying OS and begins waiting for events.
 func NewWatcher() (*Watcher, error) {
 	// Create inotify fd
-	fd, errno := syscall.InotifyInit()
+	fd, errno := unix.InotifyInit()
 	if fd == -1 {
 		return nil, errno
 	}
 	// Create epoll
 	poller, err := newFdPoller(fd)
 	if err != nil {
-		syscall.Close(fd)
+		unix.Close(fd)
 		return nil, err
 	}
 	w := &Watcher{
@@ -95,9 +95,9 @@ func (w *Watcher) Add(name string) error {
 		return errors.New("inotify instance already closed")
 	}
 
-	const agnosticEvents = syscall.IN_MOVED_TO | syscall.IN_MOVED_FROM |
-		syscall.IN_CREATE | syscall.IN_ATTRIB | syscall.IN_MODIFY |
-		syscall.IN_MOVE_SELF | syscall.IN_DELETE | syscall.IN_DELETE_SELF
+	const agnosticEvents = unix.IN_MOVED_TO | unix.IN_MOVED_FROM |
+		unix.IN_CREATE | unix.IN_ATTRIB | unix.IN_MODIFY |
+		unix.IN_MOVE_SELF | unix.IN_DELETE | unix.IN_DELETE_SELF
 
 	var flags uint32 = agnosticEvents
 
@@ -106,9 +106,9 @@ func (w *Watcher) Add(name string) error {
 	w.mu.Unlock()
 	if found {
 		watchEntry.flags |= flags
-		flags |= syscall.IN_MASK_ADD
+		flags |= unix.IN_MASK_ADD
 	}
-	wd, errno := syscall.InotifyAddWatch(w.fd, name, flags)
+	wd, errno := unix.InotifyAddWatch(w.fd, name, flags)
 	if wd == -1 {
 		return errno
 	}
@@ -140,7 +140,7 @@ func (w *Watcher) Remove(name string) error {
 	// by calling inotify_rm_watch() below. e.g. readEvents() goroutine receives IN_IGNORE
 	// so that EINVAL means that the wd is being rm_watch()ed or its file removed
 	// by another thread and we have not received IN_IGNORE event.
-	success, errno := syscall.InotifyRmWatch(w.fd, watch.wd)
+	success, errno := unix.InotifyRmWatch(w.fd, watch.wd)
 	if success == -1 {
 		// TODO: Perhaps it's not helpful to return an error here in every case.
 		// the only two possible errors are:
@@ -170,7 +170,7 @@ type watch struct {
 // received events into Event objects and sends them via the Events channel
 func (w *Watcher) readEvents() {
 	var (
-		buf   [syscall.SizeofInotifyEvent * 4096]byte // Buffer for a maximum of 4096 raw events
+		buf   [unix.SizeofInotifyEvent * 4096]byte    // Buffer for a maximum of 4096 raw events
 		n     int                                     // Number of bytes read with read()
 		errno error                                   // Syscall errno
 		ok    bool                                    // For poller.wait
@@ -179,7 +179,7 @@ func (w *Watcher) readEvents() {
 	defer close(w.doneResp)
 	defer close(w.Errors)
 	defer close(w.Events)
-	defer syscall.Close(w.fd)
+	defer unix.Close(w.fd)
 	defer w.poller.close()
 
 	for {
@@ -202,20 +202,20 @@ func (w *Watcher) readEvents() {
 			continue
 		}
 
-		n, errno = syscall.Read(w.fd, buf[:])
+		n, errno = unix.Read(w.fd, buf[:])
 		// If a signal interrupted execution, see if we've been asked to close, and try again.
 		// http://man7.org/linux/man-pages/man7/signal.7.html :
 		// "Before Linux 3.8, reads from an inotify(7) file descriptor were not restartable"
-		if errno == syscall.EINTR {
+		if errno == unix.EINTR {
 			continue
 		}
 
-		// syscall.Read might have been woken up by Close. If so, we're done.
+		// unix.Read might have been woken up by Close. If so, we're done.
 		if w.isClosed() {
 			return
 		}
 
-		if n < syscall.SizeofInotifyEvent {
+		if n < unix.SizeofInotifyEvent {
 			var err error
 			if n == 0 {
 				// If EOF is received. This should really never happen.
@@ -238,9 +238,9 @@ func (w *Watcher) readEvents() {
 		var offset uint32
 		// We don't know how many events we just read into the buffer
 		// While the offset points to at least one whole event...
-		for offset <= uint32(n-syscall.SizeofInotifyEvent) {
+		for offset <= uint32(n-unix.SizeofInotifyEvent) {
 			// Point "raw" to the event in the buffer
-			raw := (*syscall.InotifyEvent)(unsafe.Pointer(&buf[offset]))
+			raw := (*unix.InotifyEvent)(unsafe.Pointer(&buf[offset]))
 
 			mask := uint32(raw.Mask)
 			nameLen := uint32(raw.Len)
@@ -253,7 +253,7 @@ func (w *Watcher) readEvents() {
 			w.mu.Unlock()
 			if nameLen > 0 {
 				// Point "bytes" at the first byte of the filename
-				bytes := (*[syscall.PathMax]byte)(unsafe.Pointer(&buf[offset+syscall.SizeofInotifyEvent]))
+				bytes := (*[unix.PathMax]byte)(unsafe.Pointer(&buf[offset+unix.SizeofInotifyEvent]))
 				// The filename is padded with NULL bytes. TrimRight() gets rid of those.
 				name += "/" + strings.TrimRight(string(bytes[0:nameLen]), "\000")
 			}
@@ -270,7 +270,7 @@ func (w *Watcher) readEvents() {
 			}
 
 			// Move to the next event in the buffer
-			offset += syscall.SizeofInotifyEvent + nameLen
+			offset += unix.SizeofInotifyEvent + nameLen
 		}
 	}
 }
@@ -280,7 +280,7 @@ func (w *Watcher) readEvents() {
 // against files that do not exist.
 func (e *Event) ignoreLinux(w *Watcher, wd int32, mask uint32) bool {
 	// Ignore anything the inotify API says to ignore
-	if mask&syscall.IN_IGNORED == syscall.IN_IGNORED {
+	if mask&unix.IN_IGNORED == unix.IN_IGNORED {
 		w.mu.Lock()
 		defer w.mu.Unlock()
 		name := w.paths[int(wd)]
@@ -305,19 +305,19 @@ func (e *Event) ignoreLinux(w *Watcher, wd int32, mask uint32) bool {
 // newEvent returns an platform-independent Event based on an inotify mask.
 func newEvent(name string, mask uint32) Event {
 	e := Event{Name: name}
-	if mask&syscall.IN_CREATE == syscall.IN_CREATE || mask&syscall.IN_MOVED_TO == syscall.IN_MOVED_TO {
+	if mask&unix.IN_CREATE == unix.IN_CREATE || mask&unix.IN_MOVED_TO == unix.IN_MOVED_TO {
 		e.Op |= Create
 	}
-	if mask&syscall.IN_DELETE_SELF == syscall.IN_DELETE_SELF || mask&syscall.IN_DELETE == syscall.IN_DELETE {
+	if mask&unix.IN_DELETE_SELF == unix.IN_DELETE_SELF || mask&unix.IN_DELETE == unix.IN_DELETE {
 		e.Op |= Remove
 	}
-	if mask&syscall.IN_MODIFY == syscall.IN_MODIFY {
+	if mask&unix.IN_MODIFY == unix.IN_MODIFY {
 		e.Op |= Write
 	}
-	if mask&syscall.IN_MOVE_SELF == syscall.IN_MOVE_SELF || mask&syscall.IN_MOVED_FROM == syscall.IN_MOVED_FROM {
+	if mask&unix.IN_MOVE_SELF == unix.IN_MOVE_SELF || mask&unix.IN_MOVED_FROM == unix.IN_MOVED_FROM {
 		e.Op |= Rename
 	}
-	if mask&syscall.IN_ATTRIB == syscall.IN_ATTRIB {
+	if mask&unix.IN_ATTRIB == unix.IN_ATTRIB {
 		e.Op |= Chmod
 	}
 	return e

--- a/inotify_poller.go
+++ b/inotify_poller.go
@@ -8,7 +8,7 @@ package fsnotify
 
 import (
 	"errors"
-	"syscall"
+	"golang.org/x/sys/unix"
 )
 
 type fdPoller struct {
@@ -39,32 +39,32 @@ func newFdPoller(fd int) (*fdPoller, error) {
 	poller.fd = fd
 
 	// Create epoll fd
-	poller.epfd, errno = syscall.EpollCreate1(0)
+	poller.epfd, errno = unix.EpollCreate1(0)
 	if poller.epfd == -1 {
 		return nil, errno
 	}
 	// Create pipe; pipe[0] is the read end, pipe[1] the write end.
-	errno = syscall.Pipe2(poller.pipe[:], syscall.O_NONBLOCK)
+	errno = unix.Pipe2(poller.pipe[:], unix.O_NONBLOCK)
 	if errno != nil {
 		return nil, errno
 	}
 
 	// Register inotify fd with epoll
-	event := syscall.EpollEvent{
+	event := unix.EpollEvent{
 		Fd:     int32(poller.fd),
-		Events: syscall.EPOLLIN,
+		Events: unix.EPOLLIN,
 	}
-	errno = syscall.EpollCtl(poller.epfd, syscall.EPOLL_CTL_ADD, poller.fd, &event)
+	errno = unix.EpollCtl(poller.epfd, unix.EPOLL_CTL_ADD, poller.fd, &event)
 	if errno != nil {
 		return nil, errno
 	}
 
 	// Register pipe fd with epoll
-	event = syscall.EpollEvent{
+	event = unix.EpollEvent{
 		Fd:     int32(poller.pipe[0]),
-		Events: syscall.EPOLLIN,
+		Events: unix.EPOLLIN,
 	}
-	errno = syscall.EpollCtl(poller.epfd, syscall.EPOLL_CTL_ADD, poller.pipe[0], &event)
+	errno = unix.EpollCtl(poller.epfd, unix.EPOLL_CTL_ADD, poller.pipe[0], &event)
 	if errno != nil {
 		return nil, errno
 	}
@@ -80,11 +80,11 @@ func (poller *fdPoller) wait() (bool, error) {
 	// I don't know whether epoll_wait returns the number of events returned,
 	// or the total number of events ready.
 	// I decided to catch both by making the buffer one larger than the maximum.
-	events := make([]syscall.EpollEvent, 7)
+	events := make([]unix.EpollEvent, 7)
 	for {
-		n, errno := syscall.EpollWait(poller.epfd, events, -1)
+		n, errno := unix.EpollWait(poller.epfd, events, -1)
 		if n == -1 {
-			if errno == syscall.EINTR {
+			if errno == unix.EINTR {
 				continue
 			}
 			return false, errno
@@ -103,31 +103,31 @@ func (poller *fdPoller) wait() (bool, error) {
 		epollin := false
 		for _, event := range ready {
 			if event.Fd == int32(poller.fd) {
-				if event.Events&syscall.EPOLLHUP != 0 {
+				if event.Events&unix.EPOLLHUP != 0 {
 					// This should not happen, but if it does, treat it as a wakeup.
 					epollhup = true
 				}
-				if event.Events&syscall.EPOLLERR != 0 {
+				if event.Events&unix.EPOLLERR != 0 {
 					// If an error is waiting on the file descriptor, we should pretend
-					// something is ready to read, and let syscall.Read pick up the error.
+					// something is ready to read, and let unix.Read pick up the error.
 					epollerr = true
 				}
-				if event.Events&syscall.EPOLLIN != 0 {
+				if event.Events&unix.EPOLLIN != 0 {
 					// There is data to read.
 					epollin = true
 				}
 			}
 			if event.Fd == int32(poller.pipe[0]) {
-				if event.Events&syscall.EPOLLHUP != 0 {
+				if event.Events&unix.EPOLLHUP != 0 {
 					// Write pipe descriptor was closed, by us. This means we're closing down the
 					// watcher, and we should wake up.
 				}
-				if event.Events&syscall.EPOLLERR != 0 {
+				if event.Events&unix.EPOLLERR != 0 {
 					// If an error is waiting on the pipe file descriptor.
 					// This is an absolute mystery, and should never ever happen.
 					return false, errors.New("Error on the pipe descriptor.")
 				}
-				if event.Events&syscall.EPOLLIN != 0 {
+				if event.Events&unix.EPOLLIN != 0 {
 					// This is a regular wakeup, so we have to clear the buffer.
 					err := poller.clearWake()
 					if err != nil {
@@ -147,9 +147,9 @@ func (poller *fdPoller) wait() (bool, error) {
 // Close the write end of the poller.
 func (poller *fdPoller) wake() error {
 	buf := make([]byte, 1)
-	n, errno := syscall.Write(poller.pipe[1], buf)
+	n, errno := unix.Write(poller.pipe[1], buf)
 	if n == -1 {
-		if errno == syscall.EAGAIN {
+		if errno == unix.EAGAIN {
 			// Buffer is full, poller will wake.
 			return nil
 		}
@@ -161,9 +161,9 @@ func (poller *fdPoller) wake() error {
 func (poller *fdPoller) clearWake() error {
 	// You have to be woken up a LOT in order to get to 100!
 	buf := make([]byte, 100)
-	n, errno := syscall.Read(poller.pipe[0], buf)
+	n, errno := unix.Read(poller.pipe[0], buf)
 	if n == -1 {
-		if errno == syscall.EAGAIN {
+		if errno == unix.EAGAIN {
 			// Buffer is empty, someone else cleared our wake.
 			return nil
 		}
@@ -175,12 +175,12 @@ func (poller *fdPoller) clearWake() error {
 // Close all poller file descriptors, but not the one passed to it.
 func (poller *fdPoller) close() {
 	if poller.pipe[1] != -1 {
-		syscall.Close(poller.pipe[1])
+		unix.Close(poller.pipe[1])
 	}
 	if poller.pipe[0] != -1 {
-		syscall.Close(poller.pipe[0])
+		unix.Close(poller.pipe[0])
 	}
 	if poller.epfd != -1 {
-		syscall.Close(poller.epfd)
+		unix.Close(poller.epfd)
 	}
 }

--- a/inotify_poller_test.go
+++ b/inotify_poller_test.go
@@ -7,7 +7,7 @@
 package fsnotify
 
 import (
-	"syscall"
+	"golang.org/x/sys/unix"
 	"testing"
 	"time"
 )
@@ -16,7 +16,7 @@ type testFd [2]int
 
 func makeTestFd(t *testing.T) testFd {
 	var tfd testFd
-	errno := syscall.Pipe(tfd[:])
+	errno := unix.Pipe(tfd[:])
 	if errno != nil {
 		t.Fatalf("Failed to create pipe: %v", errno)
 	}
@@ -28,7 +28,7 @@ func (tfd testFd) fd() int {
 }
 
 func (tfd testFd) closeWrite(t *testing.T) {
-	errno := syscall.Close(tfd[1])
+	errno := unix.Close(tfd[1])
 	if errno != nil {
 		t.Fatalf("Failed to close write end of pipe: %v", errno)
 	}
@@ -36,7 +36,7 @@ func (tfd testFd) closeWrite(t *testing.T) {
 
 func (tfd testFd) put(t *testing.T) {
 	buf := make([]byte, 10)
-	_, errno := syscall.Write(tfd[1], buf)
+	_, errno := unix.Write(tfd[1], buf)
 	if errno != nil {
 		t.Fatalf("Failed to write to pipe: %v", errno)
 	}
@@ -44,15 +44,15 @@ func (tfd testFd) put(t *testing.T) {
 
 func (tfd testFd) get(t *testing.T) {
 	buf := make([]byte, 10)
-	_, errno := syscall.Read(tfd[0], buf)
+	_, errno := unix.Read(tfd[0], buf)
 	if errno != nil {
 		t.Fatalf("Failed to read from pipe: %v", errno)
 	}
 }
 
 func (tfd testFd) close() {
-	syscall.Close(tfd[1])
-	syscall.Close(tfd[0])
+	unix.Close(tfd[1])
+	unix.Close(tfd[0])
 }
 
 func makePoller(t *testing.T) (testFd, *fdPoller) {
@@ -66,7 +66,7 @@ func makePoller(t *testing.T) (testFd, *fdPoller) {
 
 func TestPollerWithBadFd(t *testing.T) {
 	_, err := newFdPoller(-1)
-	if err != syscall.EBADF {
+	if err != unix.EBADF {
 		t.Fatalf("Expected EBADF, got: %v", err)
 	}
 }

--- a/inotify_test.go
+++ b/inotify_test.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"syscall"
+	"golang.org/x/sys/unix"
 	"testing"
 	"time"
 )
@@ -21,7 +21,7 @@ func TestInotifyCloseRightAway(t *testing.T) {
 		t.Fatalf("Failed to create watcher")
 	}
 
-	// Close immediately; it won't even reach the first syscall.Read.
+	// Close immediately; it won't even reach the first unix.Read.
 	w.Close()
 
 	// Wait for the close to complete.
@@ -35,7 +35,7 @@ func TestInotifyCloseSlightlyLater(t *testing.T) {
 		t.Fatalf("Failed to create watcher")
 	}
 
-	// Wait until readEvents has reached syscall.Read, and Close.
+	// Wait until readEvents has reached unix.Read, and Close.
 	<-time.After(50 * time.Millisecond)
 	w.Close()
 
@@ -54,7 +54,7 @@ func TestInotifyCloseSlightlyLaterWithWatch(t *testing.T) {
 	}
 	w.Add(testDir)
 
-	// Wait until readEvents has reached syscall.Read, and Close.
+	// Wait until readEvents has reached unix.Read, and Close.
 	<-time.After(50 * time.Millisecond)
 	w.Close()
 
@@ -137,7 +137,7 @@ func TestInotifyCloseCreate(t *testing.T) {
 	}
 
 	// At this point, we've received one event, so the goroutine is ready.
-	// It's also blocking on syscall.Read.
+	// It's also blocking on unix.Read.
 	// Now we try to swap the file descriptor under its nose.
 	w.Close()
 	w, err = NewWatcher()
@@ -181,7 +181,7 @@ func TestInotifyStress(t *testing.T) {
 		for {
 			select {
 			case <-time.After(5 * time.Millisecond):
-				err := proc.Signal(syscall.SIGUSR1)
+				err := proc.Signal(unix.SIGUSR1)
 				if err != nil {
 					t.Fatalf("Signal failed: %v", err)
 				}

--- a/integration_darwin_test.go
+++ b/integration_darwin_test.go
@@ -7,7 +7,7 @@ package fsnotify
 import (
 	"os"
 	"path/filepath"
-	"syscall"
+	"golang.org/x/sys/unix"
 	"testing"
 	"time"
 )
@@ -87,7 +87,7 @@ func testExchangedataForWatcher(t *testing.T, watchDir bool) {
 		createAndSyncFile(t, intermediate)
 
 		// 1. Swap
-		if err := syscall.Exchangedata(intermediate, resolved, 0); err != nil {
+		if err := unix.Exchangedata(intermediate, resolved, 0); err != nil {
 			t.Fatalf("[%d] exchangedata failed: %s", i, err)
 		}
 

--- a/open_mode_bsd.go
+++ b/open_mode_bsd.go
@@ -6,6 +6,6 @@
 
 package fsnotify
 
-import "syscall"
+import "golang.org/x/sys/unix"
 
-const openMode = syscall.O_NONBLOCK | syscall.O_RDONLY
+const openMode = unix.O_NONBLOCK | unix.O_RDONLY

--- a/open_mode_darwin.go
+++ b/open_mode_darwin.go
@@ -6,7 +6,7 @@
 
 package fsnotify
 
-import "syscall"
+import "golang.org/x/sys/unix"
 
 // note: this constant is not defined on BSD
-const openMode = syscall.O_EVTONLY
+const openMode = unix.O_EVTONLY


### PR DESCRIPTION
The syscall package is locked since 1.4[1], all new changes are in x/sys[2]
The fixes for epoll/arm64 are going to be loaded to x/sys/unix. This
commit is straightforward search/replace with a couple of hand edits.

This is needed for fixing #130

[1] https://golang.org/s/go1.4-syscall
[2] https://godoc.org/golang.org/x/sys/unix