### PR TITLE
Properly handle inotify's IN_Q_OVERFLOW event

### DIFF
--- a/fsnotify.go
+++ b/fsnotify.go
@@ -9,6 +9,7 @@ package fsnotify
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 )
 
@@ -60,3 +61,6 @@ func (op Op) String() string {
 func (e Event) String() string {
 	return fmt.Sprintf("%q: %s", e.Name, e.Op.String())
 }
+
+// Common errors that can be reported by a watcher
+var ErrEventOverflow = errors.New("fsnotify queue overflow")

--- a/inotify.go
+++ b/inotify.go
@@ -245,6 +245,15 @@ func (w *Watcher) readEvents() {
 
 			mask := uint32(raw.Mask)
 			nameLen := uint32(raw.Len)
+
+			if mask&unix.IN_Q_OVERFLOW != 0 {
+				select {
+				case w.Errors <- errors.New("inotify queue overflow"):
+				case <-w.done:
+					return
+				}
+			}
+
 			// If the event happened to the watched directory or the watched file, the kernel
 			// doesn't append the filename to the event, but we would like to always fill the
 			// the "Name" field with a valid filename. We retrieve the path of the watch from

--- a/inotify.go
+++ b/inotify.go
@@ -248,7 +248,7 @@ func (w *Watcher) readEvents() {
 
 			if mask&unix.IN_Q_OVERFLOW != 0 {
 				select {
-				case w.Errors <- errors.New("inotify queue overflow"):
+				case w.Errors <- ErrEventOverflow:
 				case <-w.done:
 					return
 				}


### PR DESCRIPTION
Upon receiving an event with IN_Q_OVERFLOW set in the mask, generate an
error on the Errors chan, so that the application can take appropriate
action.