### PR TITLE
Update docs: relative -> absolute path

### DIFF
--- a/fsnotify.go
+++ b/fsnotify.go
@@ -14,7 +14,7 @@ import (
 
 // Event represents a single file system notification.
 type Event struct {
-	Name string // Relative path to the file or directory.
+	Name string // Absolute path to the file or directory.
 	Op   Op     // File operation that triggered the event.
 }
 


### PR DESCRIPTION
Tested on Unbutu 16.04, maybe it's a relative path on other platforms...

I was monitoring: `/tmp/EFlmKJ8XTYmnxQIucRkY2A/"` and got the event `"/tmp/EFlmKJ8XTYmnxQIucRkY2A/qmp.sock": CREATE`.