### PR TITLE
path relative to current working folder

### DIFF
--- a/fsnotify.go
+++ b/fsnotify.go
@@ -14,7 +14,7 @@ import (
 
 // Event represents a single file system notification.
 type Event struct {
-	Name string // Relative path to the file or directory.
+	Name string // File or directory path relative to current working folder.
 	Op   Op     // File operation that triggered the event.
 }
 


### PR DESCRIPTION
According to: https://github.com/fsnotify/fsnotify/pull/158#issuecomment-236961796

This is relative to cwd, which should be made clear.

It's very easy to think that it's relative to the folder being monitored.

IMO, it's a bad idea to make it a relative path, it invites mistakes...
So this might just be a docs fix.. Maybe we should file an issue for making it an absolute path.