### PR TITLE
ci: update for Go 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,14 @@ sudo: false
 language: go
 
 go:
-  - 1.6.3
+  - 1.8
+  - 1.7.x
   - tip
 
 matrix:
   allow_failures:
     - go: tip
+  fast_finish: true
 
 before_script:
   - go get -u github.com/golang/lint/golint


### PR DESCRIPTION
two most recent stable versions + tip
