### PR TITLE
Add a String() func to Event.Op

### DIFF
--- a/fsnotify.go
+++ b/fsnotify.go
@@ -30,33 +30,33 @@ const (
 	Chmod
 )
 
-// String returns a string representation of the event in the form
-// "file: REMOVE|WRITE|..."
-func (e Event) String() string {
+func (op Op) String() string {
 	// Use a buffer for efficient string concatenation
 	var buffer bytes.Buffer
 
-	if e.Op&Create == Create {
+	if op&Create == Create {
 		buffer.WriteString("|CREATE")
 	}
-	if e.Op&Remove == Remove {
+	if op&Remove == Remove {
 		buffer.WriteString("|REMOVE")
 	}
-	if e.Op&Write == Write {
+	if op&Write == Write {
 		buffer.WriteString("|WRITE")
 	}
-	if e.Op&Rename == Rename {
+	if op&Rename == Rename {
 		buffer.WriteString("|RENAME")
 	}
-	if e.Op&Chmod == Chmod {
+	if op&Chmod == Chmod {
 		buffer.WriteString("|CHMOD")
 	}
-
-	// If buffer remains empty, return no event names
 	if buffer.Len() == 0 {
-		return fmt.Sprintf("%q: ", e.Name)
+		return ""
 	}
+	return buffer.String()[1:] // Strip leading pipe
+}
 
-	// Return a list of event names, with leading pipe character stripped
-	return fmt.Sprintf("%q: %s", e.Name, buffer.String()[1:])
+// String returns a string representation of the event in the form
+// "file: REMOVE|WRITE|..."
+func (e Event) String() string {
+	return fmt.Sprintf("%q: %s", e.Name, e.Op.String())
 }

--- a/fsnotify_test.go
+++ b/fsnotify_test.go
@@ -1,0 +1,33 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !plan9
+
+package fsnotify
+
+import "testing"
+
+func TestEventStringWithValue(t *testing.T) {
+	expectedString := `"/usr/someFile": CREATE|CHMOD`
+	event := Event{Name: "/usr/someFile", Op: Chmod | Create}
+	if event.String() != expectedString {
+		t.Fatalf("Expected %s, got: %v", expectedString, event.String())
+	}
+}
+
+func TestEventOpStringWithValue(t *testing.T) {
+	expectedOpString := "WRITE|CHMOD"
+	event := Event{Name: "someFile", Op: Write | Chmod}
+	if event.Op.String() != expectedOpString {
+		t.Fatalf("Expected %s, got: %v", expectedOpString, event.Op.String())
+	}
+}
+
+func TestEventOpStringWithNoValue(t *testing.T) {
+	expectedOpString := ""
+	event := Event{Name: "testFile", Op: 0}
+	if event.Op.String() != expectedOpString {
+		t.Fatalf("Expected %s, got: %v", expectedOpString, event.Op.String())
+	}
+}

--- a/fsnotify_test.go
+++ b/fsnotify_test.go
@@ -1,4 +1,4 @@
-// Copyright 2015 The Go Authors. All rights reserved.
+// Copyright 2016 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -9,10 +9,17 @@ package fsnotify
 import "testing"
 
 func TestEventStringWithValue(t *testing.T) {
-	expectedString := `"/usr/someFile": CREATE|CHMOD`
-	event := Event{Name: "/usr/someFile", Op: Chmod | Create}
-	if event.String() != expectedString {
-		t.Fatalf("Expected %s, got: %v", expectedString, event.String())
+	for opMask, expectedString := range map[Op]string{
+		Chmod | Create: `"/usr/someFile": CREATE|CHMOD`,
+		Rename:         `"/usr/someFile": RENAME`,
+		Remove:         `"/usr/someFile": REMOVE`,
+		Write | Chmod:  `"/usr/someFile": WRITE|CHMOD`,
+	} {
+		event := Event{Name: "/usr/someFile", Op: opMask}
+		if event.String() != expectedString {
+			t.Fatalf("Expected %s, got: %v", expectedString, event.String())
+		}
+
 	}
 }
 


### PR DESCRIPTION
As a user of the library I want to use `Op.String()` to classify events by their op string without the need to parse `event.String()` or creating my own string builder.

The change delegates string representation of the event to the `Op` receiver, as suggested by a few people before.

Tested on Linux and Darwin.
`
$ go test
PASS
ok  	github.com/fsnotify/fsnotify	13.581s
`
Signed the CLA.