### PR TITLE
Fix creation of multiple mutexes guarding the same set of maps

### DIFF
--- a/inotify.go
+++ b/inotify.go
@@ -23,8 +23,8 @@ import (
 type Watcher struct {
 	Events   chan Event
 	Errors   chan error
-	mu       sync.Mutex // Map access
-	cv       *sync.Cond // sync removing on rm_watch with IN_IGNORE
+	mu       *sync.Mutex // Map access
+	cv       *sync.Cond  // sync removing on rm_watch with IN_IGNORE
 	fd       int
 	poller   *fdPoller
 	watches  map[string]*watch // Map of inotify watches (key: path)
@@ -55,8 +55,9 @@ func NewWatcher() (*Watcher, error) {
 		Errors:   make(chan error),
 		done:     make(chan struct{}),
 		doneResp: make(chan struct{}),
+		mu:       &sync.Mutex{},
 	}
-	w.cv = sync.NewCond(&w.mu)
+	w.cv = sync.NewCond(w.mu)
 
 	go w.readEvents()
 	return w, nil

--- a/kqueue.go
+++ b/kqueue.go
@@ -26,7 +26,7 @@ type Watcher struct {
 
 	kq int // File descriptor (as returned by the kqueue() syscall).
 
-	mu              sync.Mutex        // Protects access to watcher data
+	mu              *sync.Mutex       // Protects access to watcher data
 	watches         map[string]int    // Map of watched file descriptors (key: path).
 	externalWatches map[string]bool   // Map of watches added by user of the library.
 	dirFlags        map[string]uint32 // Map of watched directories to fflags used in kqueue.
@@ -57,6 +57,7 @@ func NewWatcher() (*Watcher, error) {
 		Events:          make(chan Event),
 		Errors:          make(chan error),
 		done:            make(chan bool),
+		mu:              &sync.Mutex{},
 	}
 
 	go w.readEvents()

--- a/windows.go
+++ b/windows.go
@@ -22,7 +22,7 @@ type Watcher struct {
 	Events   chan Event
 	Errors   chan error
 	isClosed bool           // Set to true when Close() is first called
-	mu       sync.Mutex     // Map access
+	mu       *sync.Mutex    // Map access
 	port     syscall.Handle // Handle to completion port
 	watches  watchMap       // Map of watches (key: i-number)
 	input    chan *input    // Inputs to the reader are sent on this channel
@@ -42,6 +42,7 @@ func NewWatcher() (*Watcher, error) {
 		Events:  make(chan Event, 50),
 		Errors:  make(chan error),
 		quit:    make(chan chan<- error, 1),
+		mu:      &sync.Mutex{},
 	}
 	go w.readEvents()
 	return w, nil


### PR DESCRIPTION
This PR addresses a problem described in https://github.com/fsnotify/fsnotify/issues/164 whereby multiple mutexes are created to guard the same set of maps, which results in concurrent access.

To see multiple mutexes with your own eyes, 
- add print statements to `inotify.go` [like this](https://gist.github.com/oozie/ec901e71053c07f86cd7c6939d1c4485).
- Run the attached integration test on the buggy code. You should see something like this:

```
Locking 0xc4200a00b0   <--- one mutex
Unlocking 0xc4200a00b0
Locking 0xc4200a00b0
Unlocking 0xc4200a00b0
Locking 0xc4200a00b0
Unlocking 0xc4200a00b0
Locking 0xc4200a0060   <---- another mutex
Unlocking 0xc4200a0060
Locking 0xc4200a0060
Unlocking 0xc4200a0060
Locking 0xc4200a00b0
Locking 0xc4200a0060
fatal error: concurrent map read and map write

```
- Healthy code should produce only one address:

```
$ go test -run Mutex
Start!
...
Unlocking 0xc4200921a0
Locking 0xc4200921a0
Unlocking 0xc4200921a0 later
Locking 0xc4200921a0
Unlocking 0xc4200921a0
Locking 0xc4200921a0
Unlocking 0xc4200921a0 later
Locking 0xc4200921a0
Unlocking 0xc4200921a0
Locking 0xc4200921a0
Unlocking 0xc4200921a0 later
Locking 0xc4200921a0
PASS
ok      github.com/fsnotify/fsnotify    0.104s
$
```

Tested on Darwin and Linux. 
CLA signed. 
