### PR TITLE
create inotify fd with close-on-exec + deflake inotify stress test

### DIFF
--- a/inotify.go
+++ b/inotify.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 	"unsafe"
 
 	"golang.org/x/sys/unix"
@@ -36,7 +37,7 @@ type Watcher struct {
 // NewWatcher establishes a new watcher with the underlying OS and begins waiting for events.
 func NewWatcher() (*Watcher, error) {
 	// Create inotify fd
-	fd, errno := unix.InotifyInit()
+	fd, errno := unix.InotifyInit1(syscall.IN_CLOEXEC)
 	if fd == -1 {
 		return nil, errno
 	}

--- a/inotify_test.go
+++ b/inotify_test.go
@@ -243,9 +243,9 @@ func TestInotifyStress(t *testing.T) {
 		}
 	}
 
-	// Drain remaining events from queues
-	finished = false
-	for !finished {
+	// Drain remaining events from channels
+	count := 0
+	for count < 10 {
 		select {
 		case err := <-errChan:
 			t.Fatalf("Got an error from file creator goroutine: %v", err)
@@ -262,7 +262,9 @@ func TestInotifyStress(t *testing.T) {
 				removes++
 			}
 		default:
-			finished = true
+			count++
+			// Give the watcher chances to fill the channels.
+			time.Sleep(time.Millisecond)
 		}
 	}
 

--- a/inotify_test.go
+++ b/inotify_test.go
@@ -10,10 +10,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
-
-	"golang.org/x/sys/unix"
 )
 
 func TestInotifyCloseRightAway(t *testing.T) {
@@ -157,7 +156,7 @@ func TestInotifyCloseCreate(t *testing.T) {
 func TestInotifyStress(t *testing.T) {
 	testDir := tempMkdir(t)
 	defer os.RemoveAll(testDir)
-	testFile := filepath.Join(testDir, "testfile")
+	testFilePrefix := filepath.Join(testDir, "testfile")
 
 	w, err := NewWatcher()
 	if err != nil {
@@ -165,84 +164,74 @@ func TestInotifyStress(t *testing.T) {
 	}
 	defer w.Close()
 
-	killchan := make(chan struct{})
-	defer close(killchan)
-
 	err = w.Add(testDir)
 	if err != nil {
 		t.Fatalf("Failed to add testDir: %v", err)
 	}
 
-	proc, err := os.FindProcess(os.Getpid())
-	if err != nil {
-		t.Fatalf("Error finding process: %v", err)
-	}
+	killChan := make(chan struct{})
+	defer close(killChan)
+
+	doneChan := make(chan struct{})
+	errChan := make(chan error, 1000)
 
 	go func() {
+		after := time.After(3 * time.Second)
+		i := 0
 		for {
 			select {
-			case <-time.After(5 * time.Millisecond):
-				err := proc.Signal(unix.SIGUSR1)
-				if err != nil {
-					t.Fatalf("Signal failed: %v", err)
-				}
-			case <-killchan:
+			case <-killChan:
+				close(doneChan)
 				return
-			}
-		}
-	}()
-
-	go func() {
-		for {
-			select {
-			case <-time.After(11 * time.Millisecond):
-				err := w.poller.wake()
-				if err != nil {
-					t.Fatalf("Wake failed: %v", err)
+			case <-after:
+				for ; i > 0; i-- {
+					testFile := fmt.Sprintf("%s%d", testFilePrefix, i)
+					err = os.Remove(testFile)
+					if err != nil {
+						errChan <- fmt.Errorf("Remove failed: %v", err)
+					}
 				}
-			case <-killchan:
-				return
-			}
-		}
-	}()
 
-	go func() {
-		for {
-			select {
-			case <-killchan:
+				close(doneChan)
 				return
 			default:
+				i++
+				testFile := fmt.Sprintf("%s%d", testFilePrefix, i)
+
 				handle, err := os.Create(testFile)
 				if err != nil {
-					t.Fatalf("Create failed: %v", err)
+					errChan <- fmt.Errorf("Create failed: %v", err)
+					continue
 				}
-				handle.Close()
-				time.Sleep(time.Millisecond)
-				err = os.Remove(testFile)
+
+				err = handle.Close()
 				if err != nil {
-					t.Fatalf("Remove failed: %v", err)
+					errChan <- fmt.Errorf("Close failed: %v", err)
+					continue
 				}
+
+				time.Sleep(time.Millisecond)
 			}
 		}
 	}()
 
 	creates := 0
 	removes := 0
-	after := time.After(5 * time.Second)
-	for {
+
+	finished := false
+	after := time.After(10 * time.Second)
+	for !finished {
 		select {
 		case <-after:
-			if creates-removes > 1 || creates-removes < -1 {
-				t.Fatalf("Creates and removes should not be off by more than one: %d creates, %d removes", creates, removes)
-			}
-			if creates < 50 {
-				t.Fatalf("Expected at least 50 creates, got %d", creates)
-			}
-			return
+			t.Fatalf("Not done")
+		case <-doneChan:
+			finished = true
+		case err := <-errChan:
+			t.Fatalf("Got an error from file creator goroutine: %v", err)
 		case err := <-w.Errors:
 			t.Fatalf("Got an error from watcher: %v", err)
 		case evt := <-w.Events:
-			if evt.Name != testFile {
+			if !strings.HasPrefix(evt.Name, testFilePrefix) {
 				t.Fatalf("Got an event for an unknown file: %s", evt.Name)
 			}
 			if evt.Op == Create {
@@ -252,6 +241,36 @@ func TestInotifyStress(t *testing.T) {
 				removes++
 			}
 		}
+	}
+
+	// Drain remaining events from queues
+	finished = false
+	for !finished {
+		select {
+		case err := <-errChan:
+			t.Fatalf("Got an error from file creator goroutine: %v", err)
+		case err := <-w.Errors:
+			t.Fatalf("Got an error from watcher: %v", err)
+		case evt := <-w.Events:
+			if !strings.HasPrefix(evt.Name, testFilePrefix) {
+				t.Fatalf("Got an event for an unknown file: %s", evt.Name)
+			}
+			if evt.Op == Create {
+				creates++
+			}
+			if evt.Op == Remove {
+				removes++
+			}
+		default:
+			finished = true
+		}
+	}
+
+	if creates-removes > 1 || creates-removes < -1 {
+		t.Fatalf("Creates and removes should not be off by more than one: %d creates, %d removes", creates, removes)
+	}
+	if creates < 50 {
+		t.Fatalf("Expected at least 50 creates, got %d", creates)
 	}
 }
 

--- a/inotify_test.go
+++ b/inotify_test.go
@@ -190,6 +190,8 @@ func TestInotifyStress(t *testing.T) {
 					if err != nil {
 						errChan <- fmt.Errorf("Remove failed: %v", err)
 					}
+
+					time.Sleep(time.Millisecond)
 				}
 
 				close(doneChan)


### PR DESCRIPTION
(on behalf of @msolo) inotify fd should not leak to children processes (this matches the kqueue implementation behavior).