### PR TITLE
Prevent concurrent map access when inspecting `Watcher`

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -7,6 +7,7 @@
 package fsnotify
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -1234,4 +1235,41 @@ func testRename(file1, file2 string) error {
 		cmd := exec.Command("mv", file1, file2)
 		return cmd.Run()
 	}
+}
+
+func TestWatcherString(t *testing.T) {
+	testDir := tempMkdir(t)
+	defer os.RemoveAll(testDir)
+	watcher, err := NewWatcher()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer watcher.Close()
+	enough := make(chan bool)
+
+	go func() {
+		for {
+			select {
+			case <-enough:
+				break
+			default:
+				watcher.Add(testDir)
+			}
+		}
+	}()
+
+	go func() {
+		for {
+			select {
+			case <-enough:
+				break
+			default:
+				fmt.Sprintf("%s", watcher)
+			}
+		}
+	}()
+
+	time.Sleep(1 * time.Second)
+	enough <- true
+	enough <- true
 }


### PR DESCRIPTION
#### What does this pull request do?

This PR addresses https://github.com/fsnotify/fsnotify/issues/166 where inspecting of `Watcher` may lead to concurrent map access.

#### Where should the reviewer start?

#166 is a good place to start. First commit is a breaking test that illustrates the problem through an example. The following commit is the fix.

#### How should this be manually tested?

use `fmt.Println` to print a watcher instance while `Add` and `Remove` calls are issued to the watcher.

