### PR TITLE
Added ACCESS as a usable event

### DIFF
--- a/fsnotify.go
+++ b/fsnotify.go
@@ -28,6 +28,7 @@ const (
 	Remove
 	Rename
 	Chmod
+	Access
 )
 
 func (op Op) String() string {
@@ -48,6 +49,9 @@ func (op Op) String() string {
 	}
 	if op&Chmod == Chmod {
 		buffer.WriteString("|CHMOD")
+	}
+	if op&Access == Access {
+		buffer.WriteString("|ACCESS")
 	}
 	if buffer.Len() == 0 {
 		return ""

--- a/inotify.go
+++ b/inotify.go
@@ -98,7 +98,7 @@ func (w *Watcher) Add(name string) error {
 
 	const agnosticEvents = unix.IN_MOVED_TO | unix.IN_MOVED_FROM |
 		unix.IN_CREATE | unix.IN_ATTRIB | unix.IN_MODIFY |
-		unix.IN_MOVE_SELF | unix.IN_DELETE | unix.IN_DELETE_SELF
+		unix.IN_MOVE_SELF | unix.IN_DELETE | unix.IN_DELETE_SELF | unix.IN_ACCESS
 
 	var flags uint32 = agnosticEvents
 
@@ -320,6 +320,9 @@ func newEvent(name string, mask uint32) Event {
 	}
 	if mask&unix.IN_ATTRIB == unix.IN_ATTRIB {
 		e.Op |= Chmod
+	}
+	if mask&unix.IN_ACCESS == unix.IN_ACCESS {
+		e.Op |= Access
 	}
 	return e
 }


### PR DESCRIPTION
#### What does this pull request do?
This pull requests introduces ACCESS as a usable event for monitoring. I am not sure whether it was omitted in purpose, but in case it wasn't, I decided to quickly add it. Since I am in need of monitoring access to specific files (not only modifications), this came handy.