### PR TITLE
Moved FAQ into the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Cross platform: Windows, Linux, BSD and macOS.
 
 \* Android and iOS are untested.
 
-Please see [the documentation](https://godoc.org/github.com/fsnotify/fsnotify) for usage. Consult the [Wiki](https://github.com/fsnotify/fsnotify/wiki) for the FAQ and further information.
+Please see [the documentation](https://godoc.org/github.com/fsnotify/fsnotify) for usage. Consult the [FAQ section](#faq) and the [Resource list](https://github.com/fsnotify/fsnotify/wiki/Reference) for further information.
 
 ## API stability
 
@@ -40,6 +40,36 @@ Please refer to [CONTRIBUTING][] before opening an issue or pull request.
 ## Example
 
 See [example_test.go](https://github.com/fsnotify/fsnotify/blob/master/example_test.go).
+
+## FAQ
+
+**When a file is moved to another directory is it still being watched?**
+
+No (it shouldn't be, unless you are watching where it was moved to).
+
+**When I watch a directory, are all subdirectories watched as well?**
+
+No, you must add watches for any directory you want to watch (a recursive watcher is in the works [#56][]).
+
+**Do I have to watch the Error and Event channels in a separate goroutine?**
+
+As of now, yes. Looking into making this single-thread friendly (see [#7][])
+
+**Why am I receiving multiple events for the same file on OS X?**
+
+Spotlight indexing on OS X can result in multiple events (see [#62][]). A temporary workaround is to add your folder(s) to the *Spotlight Privacy settings* until we have a native FSEvents implementation (see [#54][]).
+
+**How many files can be watched at once?**
+
+There are OS-specific limits as to how many watches can be created:
+* Linux: /proc/sys/fs/inotify/max_user_watches contains the limit,
+reaching this limit results in a "no space left on device" error.
+* BSD / OSX: sysctl variables "kern.maxfiles" and "kern.maxfilesperproc", reaching these limits results in a "too many open files" error.
+
+[#62]: https://github.com/howeyc/fsnotify/issues/62
+[#56]: https://github.com/howeyc/fsnotify/issues/56
+[#54]: https://github.com/howeyc/fsnotify/issues/54
+[#7]: https://github.com/howeyc/fsnotify/issues/7
 
 [contributing]: https://github.com/fsnotify/fsnotify/blob/master/CONTRIBUTING.md
 


### PR DESCRIPTION
As per #184.
Also replaced the wiki link with the list to resources page.