### PR TITLE
Watch.Add improvements (avoid race, fix consistency, reduce garbage)

### DIFF
--- a/inotify.go
+++ b/inotify.go
@@ -106,8 +106,7 @@ func (w *Watcher) Add(name string) error {
 	defer w.mu.Unlock()
 	watchEntry, found := w.watches[name]
 	if found {
-		watchEntry.flags |= flags
-		flags |= unix.IN_MASK_ADD
+		flags |= watchEntry.flags | unix.IN_MASK_ADD
 	}
 	wd, errno := unix.InotifyAddWatch(w.fd, name, flags)
 	if wd == -1 {

--- a/inotify.go
+++ b/inotify.go
@@ -103,8 +103,8 @@ func (w *Watcher) Add(name string) error {
 	var flags uint32 = agnosticEvents
 
 	w.mu.Lock()
+	defer w.mu.Unlock()
 	watchEntry, found := w.watches[name]
-	w.mu.Unlock()
 	if found {
 		watchEntry.flags |= flags
 		flags |= unix.IN_MASK_ADD
@@ -114,10 +114,8 @@ func (w *Watcher) Add(name string) error {
 		return errno
 	}
 
-	w.mu.Lock()
 	w.watches[name] = &watch{wd: uint32(wd), flags: flags}
 	w.paths[wd] = name
-	w.mu.Unlock()
 
 	return nil
 }


### PR DESCRIPTION
This PR fixes two potential problems in Watch.Add in `inotify.go`:

  * Race when `Add()` is called concurrently.
  * Incorrect `flags` stored when `InotifyAddWatch` fails.

In addition, it re-uses the existing watch entry when modifying an existing watch.

The individual commits contain more details.
