### PR TITLE
Fixes inotify not notifying on deletion of open files.

### DIFF
--- a/inotify.go
+++ b/inotify.go
@@ -309,8 +309,9 @@ func (e *Event) ignoreLinux(mask uint32) bool {
 	// event was sent after the DELETE. This ignores that MODIFY and
 	// assumes a DELETE will come or has come if the file doesn't exist.
 	// A CHMOD event (triggeded by IN_MODIFY) can arrive when an open file is
-	// deleted.  In that case the DELETE event is defered until all open
-	// handles for the file are closed.
+	// deleted.  In that case the DELETE event is deferred until all open
+	// handles for the file are closed. See
+	// https://github.com/fsnotify/fsnotify/issues/194 for more information.
 	if e.Op&Create == Create || e.Op&Write == Write {
 		_, statErr := os.Lstat(e.Name)
 		return os.IsNotExist(statErr)

--- a/inotify.go
+++ b/inotify.go
@@ -308,7 +308,7 @@ func (e *Event) ignoreLinux(mask uint32) bool {
 	// *Note*: this was put in place because it was seen that a MODIFY
 	// event was sent after the DELETE. This ignores that MODIFY and
 	// assumes a DELETE will come or has come if the file doesn't exist.
-	// A CHMOD event (triggeded by IN_MODIFY) can arrive when an open file is
+	// A CHMOD event (triggered by IN_MODIFY) can arrive when an open file is
 	// deleted.  In that case the DELETE event is deferred until all open
 	// handles for the file are closed. See
 	// https://github.com/fsnotify/fsnotify/issues/194 for more information.

--- a/inotify_test.go
+++ b/inotify_test.go
@@ -498,7 +498,7 @@ func TestInotifyDeleteOpenFile(t *testing.T) {
 			t.Fatalf("Expected second event type %s, got: %v", Remove, event.Op)
 		}
 	case <-time.After(100 * time.Millisecond):
-		t.Fatalf("Expected first event not delivered")
+		t.Fatalf("Expected second event not delivered")
 	}
 
 	w.Close()

--- a/inotify_test.go
+++ b/inotify_test.go
@@ -447,3 +447,60 @@ func TestInotifyOverflow(t *testing.T) {
 			numDirs*numFiles, creates)
 	}
 }
+
+func TestInotifyDeleteOpenFile(t *testing.T) {
+	testDir := tempMkdir(t)
+	defer os.RemoveAll(testDir)
+
+	testFile := filepath.Join(testDir, "testfile")
+
+	handle, err := os.Create(testFile)
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	w, err := NewWatcher()
+	if err != nil {
+		t.Fatalf("Failed to create watcher: %v", err)
+	}
+	defer w.Close()
+
+	err = w.Add(testFile)
+	if err != nil {
+		t.Fatalf("Failed to add watch for %s: %v", testFile, err)
+	}
+
+	go func() {
+		err = os.Remove(testFile)
+		if err != nil {
+			t.Fatalf("Failed to remove %s: %v", testFile, err)
+		}
+	}()
+
+	var event Event
+
+	select {
+	case event = <-w.Events:
+		if event.Op != Chmod {
+			t.Fatalf("Expected first event type %s, got: %v", Chmod, event.Op)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatalf("Expected first event not delivered")
+	}
+
+	handle.Close()
+	select {
+	case event = <-w.Events:
+		if event.Op != Remove {
+			t.Fatalf("Expected second event type %s, got: %v", Remove, event.Op)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatalf("Expected first event not delivered")
+	}
+
+	w.Close()
+
+	// Wait for the close to complete.
+	time.Sleep(50 * time.Millisecond)
+	isWatcherReallyClosed(t, w)
+}


### PR DESCRIPTION
#### What does this pull request do?
Fixes issue #194: no notification arrives when a file with open handles is deleted. The change essentially stops ignoring the `Chmod` notification when the file in question does not exist. Such situation can arise on Linux, when a process holds an open handle for the file and the file is being deleted. In that case the watcher receives an `IN_ATTRIB` notification to indicate the changed count of hard links to the file. But the file will not be actually deleted from disk until all open handles are closed, and correspondingly `IN_DELETE_SELF` notifications will be postponed until then. With this change, a watcher process will receive a `Chmod` notification and have a chance to respond.

#### Where should the reviewer start?
The test explains the scenario well and can be a good place to understand it better.

#### How should this be manually tested?
A unit test is included and is executed as part of the CI build. The test fails without the code change.