### PR TITLE
Also create epoll and pipe fds with close-on-exec (#155)

### DIFF
--- a/inotify_poller.go
+++ b/inotify_poller.go
@@ -40,12 +40,12 @@ func newFdPoller(fd int) (*fdPoller, error) {
 	poller.fd = fd
 
 	// Create epoll fd
-	poller.epfd, errno = unix.EpollCreate1(0)
+	poller.epfd, errno = unix.EpollCreate1(unix.EPOLL_CLOEXEC)
 	if poller.epfd == -1 {
 		return nil, errno
 	}
 	// Create pipe; pipe[0] is the read end, pipe[1] the write end.
-	errno = unix.Pipe2(poller.pipe[:], unix.O_NONBLOCK)
+	errno = unix.Pipe2(poller.pipe[:], unix.O_NONBLOCK|unix.O_CLOEXEC)
 	if errno != nil {
 		return nil, errno
 	}


### PR DESCRIPTION
* Add the unix.O_CLOEXEC to the Pipe2 call
* Add unix.EPOLL_CLOEXEC to the Epoll call

I've signed the CLA.

#### What does this pull request do?
When creating a fsnotify.NewWatcher(), four file descriptors are opened: One for inotify, one for epoll and two for the two ends of a pipe. Only the inotify one has CLOEXEC set. This PR adds the CLOEXEC flag to all four file descriptors, preventing a leak in cases where execve is used e.g. to reload an executable on code change.

#### Where should the reviewer start?
I read the manpages of pipe2 and epoll_create2 to get an idea of the flags.

#### How should this be manually tested?
In a simple program which just opens a NewWatcher, does a syscall.Exec, and sleeps, the difference in the number of open file descriptors is visible in /proc/<pid>/fd/ 
