### PR TITLE
Return error from watcher Close()

### DIFF
--- a/kqueue.go
+++ b/kqueue.go
@@ -92,7 +92,7 @@ func (w *Watcher) Close() error {
 	// Send "quit" message to the reader goroutine:
 	w.done <- true
 
-	return nil
+	return err
 }
 
 // Add starts watching the named file or directory (non-recursively).


### PR DESCRIPTION
Return error from watcher Close()

#### What does this pull request do?
Return error from Watcher.Close() in kqueue.go

#### Where should the reviewer start?
Close() in kqueue.go

#### How should this be manually tested?
Check if error can be return from Close(), it is always return `nil` for now.
