### PR TITLE
kqueue: Make watcher.Close() O(n) instead of O(n^2)

### DIFF
--- a/kqueue.go
+++ b/kqueue.go
@@ -126,6 +126,10 @@ func (w *Watcher) Remove(name string) error {
 	parentName := filepath.Dir(name)
 	delete(w.watchesByDir[parentName], watchfd)
 
+	if len(w.watchesByDir[parentName]) == 0 {
+		delete(w.watchesByDir, parentName)
+	}
+
 	delete(w.paths, watchfd)
 	delete(w.dirFlags, name)
 	w.mu.Unlock()
@@ -241,7 +245,7 @@ func (w *Watcher) addWatch(name string, flags uint32) (string, error) {
 
 		watchesByDir, ok := w.watchesByDir[parentName]
 		if !ok {
-			watchesByDir = make(map[int]struct{})
+			watchesByDir = make(map[int]struct{}, 1)
 			w.watchesByDir[parentName] = watchesByDir
 		}
 		watchesByDir[watchfd] = struct{}{}

--- a/kqueue.go
+++ b/kqueue.go
@@ -125,9 +125,6 @@ func (w *Watcher) Remove(name string) error {
 
 	parentName := filepath.Dir(name)
 	delete(w.watchesByDir[parentName], watchfd)
-	if len(w.watchesByDir[parentName]) == 0 {
-		delete(w.watchesByDir, parentName)
-	}
 
 	delete(w.paths, watchfd)
 	delete(w.dirFlags, name)


### PR DESCRIPTION
#### What does this pull request do?

Fixes a performance problem in the kqueue-based implementation of watcher.

In the old implementation, watcher.Close() would clone the list of watches, then run Remove. Each run of Remove would also iterate over the full list of watches.

This indexes the watches better so that Remove doesn't need to iterate over the full list.

#### How should this be manually tested?

There should be no functional changes in this PR