### PR TITLE
fix race condition in a integration test

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -444,7 +444,7 @@ func TestFsnotifyDeleteWatchedDir(t *testing.T) {
 	// Receive errors on the error channel on a separate goroutine
 	go func() {
 		for err := range watcher.Errors {
-			t.Fatalf("error received: %s", err)
+			t.Error("error received: %s", err)
 		}
 	}()
 


### PR DESCRIPTION
FatalF must not be called from outside the testing goroutine or this leads to a race condition within the testing package.

See https://golang.org/pkg/testing/#T.FailNow