### PR TITLE
Check if channels are closed in the example

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -24,18 +24,18 @@ func ExampleNewWatcher() {
 		for {
 			select {
 			case event, ok := <-watcher.Events:
+				if !ok {
+					return
+				}
 				log.Println("event:", event)
 				if event.Op&fsnotify.Write == fsnotify.Write {
 					log.Println("modified file:", event.Name)
 				}
-				if !ok {
-					return
-				}
 			case err, ok := <-watcher.Errors:
-				log.Println("error:", err)
 				if !ok {
 					return
 				}
+				log.Println("error:", err)
 			}
 		}
 	}()

--- a/example_test.go
+++ b/example_test.go
@@ -23,13 +23,19 @@ func ExampleNewWatcher() {
 	go func() {
 		for {
 			select {
-			case event := <-watcher.Events:
+			case event, ok := <-watcher.Events:
 				log.Println("event:", event)
 				if event.Op&fsnotify.Write == fsnotify.Write {
 					log.Println("modified file:", event.Name)
 				}
-			case err := <-watcher.Errors:
+				if !ok {
+					return
+				}
+			case err, ok := <-watcher.Errors:
 				log.Println("error:", err)
+				if !ok {
+					return
+				}
 			}
 		}
 	}()


### PR DESCRIPTION
This PR is just about adding a check for closed channels to the example https://github.com/fsnotify/fsnotify/blob/master/example_test.go

Without that check the goroutine will keep printing empty errors (nils) & events after the watcher is closed.

See https://github.com/fsnotify/fsnotify/issues/229