### PR TITLE
ADDED: CloseWrite event support

### DIFF
--- a/fsnotify.go
+++ b/fsnotify.go
@@ -29,6 +29,7 @@ const (
 	Remove
 	Rename
 	Chmod
+	CloseWrite
 )
 
 func (op Op) String() string {
@@ -49,6 +50,9 @@ func (op Op) String() string {
 	}
 	if op&Chmod == Chmod {
 		buffer.WriteString("|CHMOD")
+	}
+	if op&CloseWrite == CloseWrite {
+		buffer.WriteString("|CLOSE_WRITE")
 	}
 	if buffer.Len() == 0 {
 		return ""

--- a/inotify.go
+++ b/inotify.go
@@ -96,7 +96,8 @@ func (w *Watcher) Add(name string) error {
 
 	const agnosticEvents = unix.IN_MOVED_TO | unix.IN_MOVED_FROM |
 		unix.IN_CREATE | unix.IN_ATTRIB | unix.IN_MODIFY |
-		unix.IN_MOVE_SELF | unix.IN_DELETE | unix.IN_DELETE_SELF
+		unix.IN_MOVE_SELF | unix.IN_DELETE | unix.IN_DELETE_SELF |
+		unix.IN_CLOSE_WRITE
 
 	var flags uint32 = agnosticEvents
 
@@ -332,6 +333,9 @@ func newEvent(name string, mask uint32) Event {
 	}
 	if mask&unix.IN_ATTRIB == unix.IN_ATTRIB {
 		e.Op |= Chmod
+	}
+	if mask&unix.IN_CLOSE_WRITE == unix.IN_CLOSE_WRITE {
+		e.Op |= CloseWrite
 	}
 	return e
 }


### PR DESCRIPTION
Hello guys,

#### What does this pull request do?
When using **fsnotify** to be notified after big file writing under Linux, it is difficult to determine if writing process is terminated because *inotify* send `WRITE` event on each `write` system call.

The goal of this patch is to introduce a new sort of event named **CloseWrite** that match `IN_CLOSE_WRITE` semantic (https://www.systutorials.com/docs/linux/man/7-inotify/) and can be usefull when reading big files that must be completely written before access (such as zip files).

#### Where should the reviewer start?

As a Linux addict, I don't know how to implement **Windows** and **OS-X** ports of this patch so I just added **CloseWrite** operation in `fsnotify.go` and update `inotify.go` for **Linux** implementation. 

So, the new operation is does not work on other OSes for now.

#### How should this be manually tested?

Under **Linux** using `fsnotify.CloseWrite` as event operation mask allow to be notified only once on big file writing, when write action is finished.

Regards.