### PR TITLE
Do not suppress Chmod on non-existent file

### DIFF
--- a/inotify.go
+++ b/inotify.go
@@ -317,12 +317,12 @@ func (e *Event) ignoreLinux(mask uint32) bool {
 		return true
 	}
 
-	// If the event is not a DELETE or RENAME, the file must exist.
-	// Otherwise the event is ignored.
-	// *Note*: this was put in place because it was seen that a MODIFY
-	// event was sent after the DELETE. This ignores that MODIFY and
-	// assumes a DELETE will come or has come if the file doesn't exist.
-	if !(e.Op&Remove == Remove || e.Op&Rename == Rename) {
+	// If the event is Create or Write, the file must exist, or the
+	// event will be suppressed.
+	// *Note*: this was put in place because it was seen that a Write
+	// event was sent after the Remove. This ignores the Write and
+	// assumes a Remove will come or has come if the file doesn't exist.
+	if e.Op&Create == Create || e.Op&Write == Write {
 		_, statErr := os.Lstat(e.Name)
 		return os.IsNotExist(statErr)
 	}


### PR DESCRIPTION
Currently fsnorify suppresses a Chmod event if the file does not exist
when the event is received.

This makes it impossible to use fsnotify to detect when an opened
file is removed. In such case the Linux kernel sends IN_ATTRIB event,
as described in inotify(7) man page:

> IN_ATTRIB (*)
>        Metadata  changed—for example, permissions (e.g., chmod(2)),
>        timestamps (e.g., utimensat(2)), extended attributes  (setx‐
>        attr(2)), link count (since Linux 2.6.25; e.g., for the tar‐
>        get of link(2) and for unlink(2)), and user/group ID  (e.g.,
>        chown(2)).

(in this very case it's link count that changes).

To fix:
 * Modify the code to only suppress MODIFY and CREATE events.
 * Add a test case to verify Chmod event is delivered.

While at it, fix the comment in ignoreLinux() to use the up-to-date
terminology (event ops).

This is heavily based on https://github.com/fsnotify/fsnotify/pull/205; kudos to @vladlosev for his work.

Fixes https://github.com/fsnotify/fsnotify/issues/194.

**Update**
> Please indicate that you have signed the CLA in your pull request.

Yes I did