### PR TITLE
add Solaris FEN support

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,8 +8,10 @@
 
 # Please keep the list sorted.
 
+Aaron L <aaron@bettercoder.net>
 Adrien Bustany <adrien@bustany.org>
 Amit Krishnan <amit.krishnan@oracle.com>
+Anmol Sethi <me@anmol.io>
 Bjørn Erik Pedersen <bjorn.erik.pedersen@gmail.com>
 Bruno Bigras <bigras.bruno@gmail.com>
 Caleb Spare <cespare@gmail.com>
@@ -26,6 +28,7 @@ Kelvin Fo <vmirage@gmail.com>
 Ken-ichirou MATSUZAWA <chamas@h4.dion.ne.jp>
 Matt Layher <mdlayher@gmail.com>
 Nathan Youngman <git@nathany.com>
+Nickolai Zeldovich <nickolai@csail.mit.edu>
 Patrick <patrick@dropbox.com>
 Paul Hammond <paul@paulhammond.org>
 Pawel Knap <pawelknap88@gmail.com>
@@ -33,12 +36,15 @@ Pieter Droogendijk <pieter@binky.org.uk>
 Pursuit92 <JoshChase@techpursuit.net>
 Riku Voipio <riku.voipio@linaro.org>
 Rob Figueiredo <robfig@gmail.com>
+Rodrigo Chiossi <rodrigochiossi@gmail.com>
 Slawek Ligus <root@ooz.ie>
 Soge Zhang <zhssoge@gmail.com>
 Tiffany Jernigan <tiffany.jernigan@intel.com>
 Tilak Sharma <tilaks@google.com>
+Tom Payne <twpayne@gmail.com>
 Travis Cline <travis.cline@gmail.com>
 Tudor Golubenco <tudor.g@gmail.com>
+Vahe Khachikyan <vahe@live.ca>
 Yukang <moorekang@gmail.com>
 bronze1man <bronze1man@gmail.com>
 debrando <denis.brandolini@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -22,7 +22,9 @@ Daniel Wagner-Hall <dawagner@gmail.com>
 Dave Cheney <dave@cheney.net>
 Evan Phoenix <evan@fallingsnow.net>
 Francisco Souza <f@souza.cc>
+Gereon Frey <gereon.frey@gmail.com>
 Hari haran <hariharan.uno@gmail.com>
+Isaac Davis <isaac.davis@joyent.com>
 John C Barstow
 Kelvin Fo <vmirage@gmail.com>
 Ken-ichirou MATSUZAWA <chamas@h4.dion.ne.jp>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v1.4.7 / 2018-01-09
+
+* BSD/macOS: Fix possible deadlock on closing the watcher on kqueue (thanks @nhooyr and @glycerine)
+* Tests: Fix missing verb on format string (thanks @rchiossi)
+* Linux: Fix deadlock in Remove (thanks @aarondl)
+* Linux: Watch.Add improvements (avoid race, fix consistency, reduce garbage) (thanks @twpayne)
+* Docs: Moved FAQ into the README (thanks @vahe)
+* Linux: Properly handle inotify's IN_Q_OVERFLOW event (thanks @zeldovich)
+* Docs: replace references to OS X with macOS
+
 ## v1.4.2 / 2016-10-10
 
 * Linux: use InotifyInit1 with IN_CLOEXEC to stop leaking a file descriptor to a child process when using fork/exec [#178](https://github.com/fsnotify/fsnotify/pull/178) (thanks @pattyshack)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.5.0 / 2018-08-28
+
+* Solaris: add support for File Event Notifications (fen) [#12](https://github.com/fsnotify/fsnotify/issues/12)
+
 ## v1.4.7 / 2018-01-09
 
 * BSD/macOS: Fix possible deadlock on closing the watcher on kqueue (thanks @nhooyr and @glycerine)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,117 @@
+pipeline {
+	agent any
+	environment {
+		SRC_DIR = "${env.WORKSPACE}"
+	}
+	stages {
+		stage('Build') {
+			parallel {
+				stage('1.11') {
+					environment {
+						GOVERSION = '1.11.1'
+						GOROOT = "/opt/go/${env.GOVERSION}"
+						GOPATH = "/home/jenkins/fsnotify-ws/${env.GIT_BRANCH}/go${env.GOVERSION}"
+						GO = "${env.GOROOT}/bin/go"
+						GOFMT = "${env.GOROOT}/bin/gofmt"
+						GOLINT = "${env.GOPATH}/bin/golint"
+					}
+					steps {
+						ws("${env.GOPATH}") {
+							sh "mkdir -p src/github.com/fsnotify/fsnotify"
+							sh "rsync -az ${SRC_DIR}/ src/github.com/fsnotify/fsnotify/"
+							dir("src/github.com/fsnotify/fsnotify") {
+								sh "${GO} version"
+								sh "${GO} env"
+								sh "${GO} get -t -v ./..."
+								sh "${GO} get -u golang.org/x/lint/golint"
+								sh "${GO} test ./..."
+								sh "test -z \"\$(${GOFMT} -s -l -w . | tee /dev/stderr)\""
+								sh "test -z \"\$(${GOLINT} ./... | tee /dev/stderr)\""
+								sh "${GO} vet ./..."
+							}
+						}
+					}
+				}
+				stage('1.10') {
+					environment {
+						GOVERSION = '1.10.4'
+						GOROOT = "/opt/go/${env.GOVERSION}"
+						GOPATH = "/home/jenkins/fsnotify-ws/${env.GIT_BRANCH}/go${env.GOVERSION}"
+						GO = "${env.GOROOT}/bin/go"
+						GOFMT = "${env.GOROOT}/bin/gofmt"
+						GOLINT = "${env.GOPATH}/bin/golint"
+					}
+					steps {
+						ws("${env.GOPATH}") {
+							sh "mkdir -p src/github.com/fsnotify/fsnotify"
+							sh "rsync -az ${SRC_DIR}/ src/github.com/fsnotify/fsnotify/"
+							dir("src/github.com/fsnotify/fsnotify") {
+								sh "${GO} version"
+								sh "${GO} env"
+								sh "${GO} get -t -v ./..."
+								sh "${GO} get -u golang.org/x/lint/golint"
+								sh "${GO} test ./..."
+								sh "test -z \"\$(${GOFMT} -s -l -w . | tee /dev/stderr)\""
+								sh "test -z \"\$(${GOLINT} ./... | tee /dev/stderr)\""
+								sh "${GO} vet ./..."
+							}
+						}
+					}
+				}
+				stage('1.9') {
+					environment {
+						GOVERSION = '1.9.7'
+						GOROOT = "/opt/go/${env.GOVERSION}"
+						GOPATH = "/home/jenkins/fsnotify-ws/${env.GIT_BRANCH}/go${env.GOVERSION}"
+						GO = "${env.GOROOT}/bin/go"
+						GOFMT = "${env.GOROOT}/bin/gofmt"
+						GOLINT = "${env.GOPATH}/bin/golint"
+					}
+					steps {
+						ws("${env.GOPATH}") {
+							sh "mkdir -p src/github.com/fsnotify/fsnotify"
+							sh "rsync -az ${SRC_DIR}/ src/github.com/fsnotify/fsnotify/"
+							dir("src/github.com/fsnotify/fsnotify") {
+								sh "${GO} version"
+								sh "${GO} env"
+								sh "${GO} get -t -v ./..."
+								sh "${GO} get -u golang.org/x/lint/golint"
+								sh "${GO} test ./..."
+								sh "test -z \"\$(${GOFMT} -s -l -w . | tee /dev/stderr)\""
+								sh "test -z \"\$(${GOLINT} ./... | tee /dev/stderr)\""
+								sh "${GO} vet ./..."
+							}
+						}
+					}
+				}
+				stage('1.8') {
+					environment {
+						GOVERSION = '1.8.7'
+						GOROOT = "/opt/go/${env.GOVERSION}"
+						GOPATH = "/home/jenkins/fsnotify-ws/${env.GIT_BRANCH}/go${env.GOVERSION}"
+						GO = "${env.GOROOT}/bin/go"
+						GOFMT = "${env.GOROOT}/bin/gofmt"
+						GOLINT = "${env.GOPATH}/bin/golint"
+					}
+					steps {
+						ws("${env.GOPATH}") {
+							sh "mkdir -p src/github.com/fsnotify/fsnotify"
+							sh "rsync -az ${SRC_DIR}/ src/github.com/fsnotify/fsnotify/"
+							dir("src/github.com/fsnotify/fsnotify") {
+								sh "${GO} version"
+								sh "${GO} env"
+								sh "${GO} get -t -v ./..."
+								sh "${GO} get -u golang.org/x/lint/golint"
+								sh "${GO} test ./..."
+								sh "test -z \"\$(${GOFMT} -s -l -w . | tee /dev/stderr)\""
+								sh "test -z \"\$(${GOLINT} ./... | tee /dev/stderr)\""
+								sh "${GO} vet ./..."
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
+

--- a/fen.go
+++ b/fen.go
@@ -205,9 +205,11 @@ func (w *Watcher) handleDirectory(path string, stat os.FileInfo, handler func(st
 
 	// Handle all children of the directory.
 	for _, finfo := range files {
-		err := handler(filepath.Join(path, finfo.Name()), finfo)
-		if err != nil {
-			return err
+		if !finfo.IsDir() {
+			err := handler(filepath.Join(path, finfo.Name()), finfo)
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/fen.go
+++ b/fen.go
@@ -6,32 +6,352 @@
 
 package fsnotify
 
+// #include <errno.h>
+// #include <strings.h>
+// #include <unistd.h>
+// #include <stdio.h>
+// #include <port.h>
+// #include <sys/stat.h>
+//
+// uintptr_t from_file_obj(struct file_obj *obj) {
+//   return (uintptr_t)obj;
+// }
+//
+// struct file_obj*to_file_obj(uintptr_t ptr) {
+//   return (struct file_obj*)ptr;
+// }
+//
+// struct file_info {
+//   uint mode;
+// };
+import "C"
 import (
 	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"unsafe"
 )
 
 // Watcher watches a set of files, delivering events to a channel.
 type Watcher struct {
 	Events chan Event
 	Errors chan error
+
+	port C.int // solaris port for underlying FEN system
+
+	mu      sync.Mutex
+	watches map[string]*C.struct_file_obj
+
+	done     chan struct{} // Channel for sending a "quit message" to the reader goroutine
+	doneResp chan struct{} // Channel to respond to Close
 }
 
 // NewWatcher establishes a new watcher with the underlying OS and begins waiting for events.
 func NewWatcher() (*Watcher, error) {
-	return nil, errors.New("FEN based watcher not yet supported for fsnotify\n")
+	var err error
+
+	w := new(Watcher)
+	w.Events = make(chan Event)
+	w.Errors = make(chan error)
+	w.port, err = C.port_create()
+	if err != nil {
+		return nil, err
+	}
+	w.watches = make(map[string]*C.struct_file_obj)
+	w.done = make(chan struct{})
+	w.doneResp = make(chan struct{})
+
+	go w.readEvents()
+	return w, nil
+}
+
+// sendEvent attempts to send an event to the user, returning true if the event
+// was put in the channel successfully and false if the watcher has been closed.
+func (w *Watcher) sendEvent(e Event) (sent bool) {
+	select {
+	case w.Events <- e:
+		return true
+	case <-w.done:
+		return false
+	}
+}
+
+// sendError attempts to send an event to the user, returning true if the error
+// was put in the channel successfully and false if the watcher has been closed.
+func (w *Watcher) sendError(err error) (sent bool) {
+	select {
+	case w.Errors <- err:
+		return true
+	case <-w.done:
+		return false
+	}
+}
+
+func (w *Watcher) isClosed() bool {
+	select {
+	case <-w.done:
+		return true
+	default:
+		return false
+	}
 }
 
 // Close removes all watches and closes the events channel.
 func (w *Watcher) Close() error {
+	if w.isClosed() {
+		return nil
+	}
+	close(w.done)
+	C.close(w.port)
+	<-w.doneResp
 	return nil
 }
 
 // Add starts watching the named file or directory (non-recursively).
-func (w *Watcher) Add(name string) error {
-	return nil
+func (w *Watcher) Add(path string) error {
+	if w.isClosed() {
+		return errors.New("FEN watcher already closed")
+	}
+	stat, err := os.Stat(path)
+	switch {
+	case err != nil:
+		return err
+	case stat.IsDir():
+		return w.handleDirectory(path, stat, w.associateFile)
+	default:
+		return w.associateFile(path, stat)
+	}
 }
 
 // Remove stops watching the the named file or directory (non-recursively).
-func (w *Watcher) Remove(name string) error {
+func (w *Watcher) Remove(path string) error {
+	if w.isClosed() {
+		return errors.New("FEN watcher already closed")
+	}
+	if !w.watched(path) {
+		return fmt.Errorf("can't remove non-existent FEN watch for: %s", path)
+	}
+
+	stat, err := os.Stat(path)
+	switch {
+	case err != nil:
+		return err
+	case stat.IsDir():
+		return w.handleDirectory(path, stat, w.dissociateFile)
+	default:
+		return w.dissociateFile(path, stat)
+	}
+}
+
+// readEvents contains the main loop that runs in a goroutine watching for events.
+func (w *Watcher) readEvents() {
+	// If this function returns, the watcher has been closed and we can
+	// close these channels
+	defer close(w.doneResp)
+	defer close(w.Errors)
+	defer close(w.Events)
+
+	for {
+		var pevent C.port_event_t
+		_, err := C.port_get(w.port, &pevent, nil)
+		if err != nil {
+			// port_get failed because we called w.Close()
+			if w.isClosed() {
+				return
+			}
+			// There was an error not caused by calling w.Close()
+			if !w.sendError(err) {
+				return
+			}
+		}
+
+		if pevent.portev_source != C.PORT_SOURCE_FILE {
+			// Event from unexpected source received; should never happen.
+			if !w.sendError(errors.New("Event from unexpected source received")) {
+				return
+			}
+			continue
+		}
+
+		finfo := (*C.struct_file_info)(pevent.portev_user)
+		err = w.handleEvent(pevent.portev_object, pevent.portev_events, finfo)
+		if err != nil {
+			if !w.sendError(err) {
+				return
+			}
+		}
+	}
+}
+
+func (w *Watcher) handleDirectory(path string, stat os.FileInfo, handler func(string, os.FileInfo) error) error {
+	files, err := ioutil.ReadDir(path)
+	if err != nil {
+		return err
+	}
+
+	// Handle all children of the directory.
+	for _, finfo := range files {
+		err := handler(filepath.Join(path, finfo.Name()), finfo)
+		if err != nil {
+			return err
+		}
+	}
+
+	// And finally handle the directory itself.
+	return handler(path, stat)
+}
+
+func (w *Watcher) handleEvent(obj C.uintptr_t, events C.int, finfo *C.struct_file_info) error {
+	fobj := C.to_file_obj(obj)
+	path := C.GoString(fobj.fo_name)
+	fmode := os.FileMode(finfo.mode)
+
+	var toSend *Event
+	reRegister := true
+
+	switch {
+	case events&C.FILE_MODIFIED == C.FILE_MODIFIED:
+		if fmode.IsDir() {
+			if err := w.updateDirectory(path); err != nil {
+				return err
+			}
+		} else {
+			toSend = &Event{path, Write}
+		}
+	case events&C.FILE_ATTRIB == C.FILE_ATTRIB:
+		toSend = &Event{path, Chmod}
+	case events&C.FILE_DELETE == C.FILE_DELETE:
+		w.unwatch(path)
+		toSend = &Event{path, Remove}
+		reRegister = false
+	case events&C.FILE_RENAME_TO == C.FILE_RENAME_TO:
+		// We don't report a Rename event for this case, because
+		// Rename events are interpreted as referring to the _old_ name
+		// of the file, and in this case the event would refer to the
+		// new name of the file. This type of rename event is not
+		// supported by fsnotify.
+
+		// inotify reports a Remove event in this case, so we simulate
+		// this here.
+		if w.watched(path) {
+			toSend = &Event{path, Remove}
+		}
+		// Don't keep watching the file that was removed
+		w.unwatch(path)
+		reRegister = false
+	case events&C.FILE_RENAME_FROM == C.FILE_RENAME_FROM:
+		toSend = &Event{path, Rename}
+		// Don't keep watching the new file name
+		w.unwatch(path)
+		reRegister = false
+	default:
+		return errors.New("unknown event received")
+	}
+
+	if toSend != nil {
+		if !w.sendEvent(*toSend) {
+			return nil
+		}
+	}
+	if !reRegister {
+		return nil
+	}
+
+	// If we get here, it means we've hit an event above that requires us to
+	// continue watching the file
+	stat, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	return w.associateFile(path, stat)
+}
+
+func (w *Watcher) updateDirectory(path string) error {
+	// The directory was modified, so we must find unwatched entites and
+	// watch them. If something was removed from the directory, nothing will
+	// happen, as everything else should still be watched.
+	files, err := ioutil.ReadDir(path)
+	if err != nil {
+		return err
+	}
+
+	for _, finfo := range files {
+		path := filepath.Join(path, finfo.Name())
+		if w.watched(path) {
+			continue
+		}
+
+		err := w.associateFile(path, finfo)
+		if err != nil {
+			if !w.sendError(err) {
+				return nil
+			}
+		}
+		if !w.sendEvent(Event{path, Create}) {
+			return nil
+		}
+	}
 	return nil
+}
+
+func (w *Watcher) associateFile(path string, stat os.FileInfo) error {
+	fobj := buildFileObj(path, stat)
+	w.watch(path, &fobj)
+
+	var finfo C.struct_file_info
+	finfo.mode = C.uint(stat.Mode())
+
+	mode := C.FILE_MODIFIED | C.FILE_ATTRIB | C.FILE_NOFOLLOW
+
+	_, err := C.port_associate(w.port, C.PORT_SOURCE_FILE, C.from_file_obj(&fobj), C.int(mode), unsafe.Pointer(&finfo))
+	return err
+}
+
+func (w *Watcher) dissociateFile(path string, stat os.FileInfo) error {
+	if !w.watched(path) {
+		return nil
+	}
+	fobj := w.unwatch(path)
+
+	_, err := C.port_dissociate(w.port, C.PORT_SOURCE_FILE, C.from_file_obj(fobj))
+	return err
+}
+
+func buildFileObj(path string, stat os.FileInfo) C.struct_file_obj {
+	var fobj C.struct_file_obj
+	fobj.fo_name = C.CString(path)
+	fobj.fo_atime.tv_sec = C.time_t(stat.Sys().(*syscall.Stat_t).Atim.Sec)
+	fobj.fo_atime.tv_nsec = C.long(stat.Sys().(*syscall.Stat_t).Atim.Nsec)
+
+	fobj.fo_mtime.tv_sec = C.time_t(stat.Sys().(*syscall.Stat_t).Mtim.Sec)
+	fobj.fo_mtime.tv_nsec = C.long(stat.Sys().(*syscall.Stat_t).Mtim.Nsec)
+
+	fobj.fo_ctime.tv_sec = C.time_t(stat.Sys().(*syscall.Stat_t).Ctim.Sec)
+	fobj.fo_ctime.tv_nsec = C.long(stat.Sys().(*syscall.Stat_t).Ctim.Nsec)
+	return fobj
+}
+
+func (w *Watcher) watched(path string) bool {
+	w.mu.Lock()
+	_, found := w.watches[path]
+	w.mu.Unlock()
+	return found
+}
+
+func (w *Watcher) unwatch(path string) *C.struct_file_obj {
+	w.mu.Lock()
+	fobj := w.watches[path]
+	delete(w.watches, path)
+	w.mu.Unlock()
+	return fobj
+}
+
+func (w *Watcher) watch(path string, fobj *C.struct_file_obj) {
+	w.mu.Lock()
+	w.watches[path] = fobj
+	w.mu.Unlock()
 }

--- a/integration_test.go
+++ b/integration_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !plan9,!solaris
+// +build !plan9
 
 package fsnotify
 


### PR DESCRIPTION
This pull request fixes #12.

I'm an employee of Joyent, Inc., and have completed the Google corporate CLA.

#### What does this pull request do?

This pull request adds fsnotify support for Solaris and illumos via Solaris FEN. It is heavily based on  #196, authored by @gfrey. As such, and with his approval, I have added @gfrey in the `AUTHORS` file in addition to myself.

One major revision to @gfrey's work concerns liveness when the watcher is closed when there is an unconsumed event in the channel - the old pull request would sometimes hang on the TestWatcherClose test. The new concurrency model is borrowed from fsnotify's inotify implementation.

Another major revision concerns proper translation of FEN events to fsnotify events, in particular the `FILE_RENAME_TO` FEN event.

#### Where should the reviewer start?

These pages are useful as an introduction to FEN:
* https://xnet.fi/solaris/
* https://solarisrants.wordpress.com/2013/07/24/solaris-file-event-notification/

The illumos man pages for [port_create](https://illumos.org/man/3C/port_create) and related functions are also helpful for understanding how to interface with FEN.

The discussion on #196 is also worth reading. Some points I'll address here:
* The use of `syscall` appears necessary here because `golang.org/x/sys/unix` does not (to my knowledge) provide a way to get atime and ctime.
* `cgo` is used because, for illumos, the officially supported interface to the OS is libc rather than syscalls, and thus user-level code should refrain from making syscalls directly.

#### How should this be manually tested?
I ran all tests on a SmartOS host. On SmartOS, Go can be installed from Joyent's [pkgsrc](https://pkgsrc.joyent.com/) repository. fsnotify can then be built and tested as normal.
