### PR TITLE
Fix TestInotifyOverflow

### DIFF
--- a/inotify_test.go
+++ b/inotify_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -390,9 +391,12 @@ func TestInotifyOverflow(t *testing.T) {
 
 	errChan := make(chan error, numDirs*numFiles)
 
+	// All events need to be in the inotify queue before pulling events off it to trigger this error.
+	wg := sync.WaitGroup{}
 	for dn := 0; dn < numDirs; dn++ {
 		testSubdir := fmt.Sprintf("%s/%d", testDir, dn)
 
+		wg.Add(1)
 		go func() {
 			for fn := 0; fn < numFiles; fn++ {
 				testFile := fmt.Sprintf("%s/%d", testSubdir, fn)
@@ -409,8 +413,10 @@ func TestInotifyOverflow(t *testing.T) {
 					continue
 				}
 			}
+			wg.Done()
 		}()
 	}
+	wg.Wait()
 
 	creates := 0
 	overflows := 0


### PR DESCRIPTION
* Queued inotify events could have been read by the test before max_queued_events was hit

#### What does this pull request do?
Fixes a race condition in the TestInotifyOverflow test

#### Where should the reviewer start?
Pretty small change

#### How should this be manually tested?
go test -run TestInotifyOverflow -count 10 on a multicore machine
