### PR TITLE
Extend kevent timeout

### DIFF
--- a/kqueue.go
+++ b/kqueue.go
@@ -151,7 +151,7 @@ func (w *Watcher) Remove(name string) error {
 const noteAllEvents = unix.NOTE_DELETE | unix.NOTE_WRITE | unix.NOTE_ATTRIB | unix.NOTE_RENAME
 
 // keventWaitTime to block on each read from kevent
-var keventWaitTime = durationToTimespec(100 * time.Millisecond)
+var keventWaitTime = durationToTimespec(time.Second)
 
 // addWatch adds name to the watched file set.
 // The flags are interpreted as described in kevent(2).


### PR DESCRIPTION
#### What does this pull request do?
https://github.com/fsnotify/fsnotify/issues/237

#### Where should the reviewer start?
The changed line

#### How should this be manually tested?
1. start a watcher on MacOS platform, monitor CPU usage.
2. change the timeout number, then retest 
