### PR TITLE
only run golint on latest version of go

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,24 +3,29 @@ language: go
 
 go:
   - "stable"
-  - "1.10.4"
+  - "1.11.x"
+  - "1.10.x"
   - "1.9.x"
   - "1.8.x"
 
 matrix:
+  include:
+    - go: "stable"
+      env: GOLINT=true
   allow_failures:
     - go: tip
   fast_finish: true
 
-before_script:
-  - go get -u golang.org/x/lint/golint
+
+before_install:
+  - if [ ! -z "${GOLINT}" ]; then go get -u golang.org/x/lint/golint; fi
 
 script:
   - go test --race ./...
 
 after_script:
   - test -z "$(gofmt -s -l -w . | tee /dev/stderr)"
-  - test -z "$(golint ./...     | tee /dev/stderr)"
+  - if [ ! -z  "${GOLINT}" ]; then echo running golint; golint --set_exit_status  ./...; else echo skipping golint; fi
   - go vet ./...
 
 os:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ after_script:
 os:
   - linux
   - osx
+  - windows
 
 notifications:
   email: false

--- a/fsnotify.go
+++ b/fsnotify.go
@@ -63,4 +63,6 @@ func (e Event) String() string {
 }
 
 // Common errors that can be reported by a watcher
-var ErrEventOverflow = errors.New("fsnotify queue overflow")
+var (
+	ErrEventOverflow = errors.New("fsnotify queue overflow")
+)


### PR DESCRIPTION
#### What does this pull request do?
- Changes travis config to only run golint on latest go version
- Adds 1.11 and 1.12 to to the go version list to test against

#### Where should the reviewer start?
Does CI pass?
Does golint run on go1.12?

#### How should this be manually tested?
N/A

Fixes #275
Closes #271 
