### PR TITLE
[bugfix] close handle when remWatch open in getIno

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -452,6 +452,8 @@ func TestClose(t *testing.T) {
 	})
 }
 
+// TODO: should also check internal state is correct/cleaned up; e.g. no
+//       left-over file descriptors or whatnot.
 func TestRemove(t *testing.T) {
 	t.Run("works", func(t *testing.T) {
 		t.Parallel()
@@ -473,6 +475,24 @@ func TestRemove(t *testing.T) {
 		have := w.stop(t)
 		if len(have) > 0 {
 			t.Errorf("received events; expected none:\n%s", have)
+		}
+	})
+
+	t.Run("remove same dir twice", func(t *testing.T) {
+		tmp := t.TempDir()
+
+		touch(t, tmp, "file")
+
+		w := newWatcher(t)
+		defer w.Close()
+
+		addWatch(t, w, tmp)
+
+		if err := w.Remove(tmp); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.Remove(tmp); err == nil {
+			t.Fatal("no error")
 		}
 	})
 

--- a/windows.go
+++ b/windows.go
@@ -327,6 +327,9 @@ func (w *Watcher) remWatch(pathname string) error {
 	w.mu.Lock()
 	watch := w.watches.get(ino)
 	w.mu.Unlock()
+    if e := syscall.CloseHandle(ino.handle); e != nil {
+		w.Errors <- os.NewSyscallError("CloseHandle", e)
+	}
 	if watch == nil {
 		return fmt.Errorf("%w: %s", ErrNonExistentWatch, pathname)
 	}

--- a/windows.go
+++ b/windows.go
@@ -327,8 +327,8 @@ func (w *Watcher) remWatch(pathname string) error {
 	w.mu.Lock()
 	watch := w.watches.get(ino)
 	w.mu.Unlock()
-    if e := syscall.CloseHandle(ino.handle); e != nil {
-		w.Errors <- os.NewSyscallError("CloseHandle", e)
+	if err := syscall.CloseHandle(ino.handle); err != nil {
+		w.Errors <- os.NewSyscallError("CloseHandle", err)
 	}
 	if watch == nil {
 		return fmt.Errorf("%w: %s", ErrNonExistentWatch, pathname)


### PR DESCRIPTION
#### What does this pull request do?
when i remWatch a directory using remWatch, and then delete the directory ,and i find the directory is still in there but i can't access because a handle is still open

#### Where should the reviewer start?


#### How should this be manually tested?

see #42 ,the gist by timshannon  (https://gist.github.com/timshannon/603f92824c5294269797)
