### PR TITLE
Add AddRaw method which does not follow symlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,18 @@ func main() {
 		}
 	}()
 
+	// if this is a link, it will follow all the links and watch the file pointed to
 	err = watcher.Add("/tmp/foo")
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	// this will watch the link, rather than the file it points to
+	err = watcher.AddRaw("/tmp/link")
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	<-done
 }
 ```
@@ -89,6 +97,10 @@ Please refer to [CONTRIBUTING][] before opening an issue or pull request.
 See [example_test.go](https://github.com/fsnotify/fsnotify/blob/master/example_test.go).
 
 ## FAQ
+
+**Are symlinks resolved?**
+Symlinks are implicitly resolved by [`filepath.EvalSymlinks(path)`](https://golang.org/pkg/path/filepath/#EvalSymlinks) when `watcher.Add(name)` is used. If that is not desired, you can use `watcher.AddRaw(name)` to not follow any symlinks before watching. See [example_test.go](https://github.com/fsnotify/fsnotify/blob/master/example_test.go).
+
 
 **When a file is moved to another directory is it still being watched?**
 
@@ -127,4 +139,3 @@ fsnotify requires support from underlying OS to work. The current NFS protocol d
 
 * [notify](https://github.com/rjeczalik/notify)
 * [fsevents](https://github.com/fsnotify/fsevents)
-

--- a/fen.go
+++ b/fen.go
@@ -26,8 +26,8 @@ func (w *Watcher) Close() error {
 	return nil
 }
 
-// Add starts watching the named file or directory (non-recursively).
-func (w *Watcher) Add(name string) error {
+// AddRaw starts watching the named file or directory (non-recursively). Symlinks are not implicitly resolved.
+func (w *Watcher) AddRaw(name string) error {
 	return nil
 }
 

--- a/fsnotify.go
+++ b/fsnotify.go
@@ -11,6 +11,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"path/filepath"
 )
 
 // Event represents a single file system notification.
@@ -66,3 +67,19 @@ func (e Event) String() string {
 var (
 	ErrEventOverflow = errors.New("fsnotify queue overflow")
 )
+
+// Add starts watching the named file or directory (non-recursively). Symlinks are implicitly resolved.
+func (w *Watcher) Add(name string) error {
+	rawPath, err := filepath.EvalSymlinks(name)
+	if err != nil {
+		return fmt.Errorf("error resolving %#v: %s", name, err)
+	}
+	err = w.AddRaw(rawPath)
+	if err != nil {
+		if name != rawPath {
+			return fmt.Errorf("error adding %#v for %#v: %s", rawPath, name, err)
+		}
+		return err
+	}
+	return nil
+}

--- a/fsnotify_test.go
+++ b/fsnotify_test.go
@@ -51,7 +51,7 @@ func TestWatcherClose(t *testing.T) {
 
 	name := tempMkFile(t, "")
 	w := newWatcher(t)
-	err := w.Add(name)
+	err := w.AddRaw(name)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/inotify.go
+++ b/inotify.go
@@ -87,8 +87,8 @@ func (w *Watcher) Close() error {
 	return nil
 }
 
-// Add starts watching the named file or directory (non-recursively).
-func (w *Watcher) Add(name string) error {
+// AddRaw starts watching the named file or directory (non-recursively). Symlinks are not implicitly resolved.
+func (w *Watcher) AddRaw(name string) error {
 	name = filepath.Clean(name)
 	if w.isClosed() {
 		return errors.New("inotify instance already closed")
@@ -96,7 +96,7 @@ func (w *Watcher) Add(name string) error {
 
 	const agnosticEvents = unix.IN_MOVED_TO | unix.IN_MOVED_FROM |
 		unix.IN_CREATE | unix.IN_ATTRIB | unix.IN_MODIFY |
-		unix.IN_MOVE_SELF | unix.IN_DELETE | unix.IN_DELETE_SELF
+		unix.IN_MOVE_SELF | unix.IN_DELETE | unix.IN_DELETE_SELF | unix.IN_DONT_FOLLOW
 
 	var flags uint32 = agnosticEvents
 

--- a/inotify_test.go
+++ b/inotify_test.go
@@ -53,7 +53,7 @@ func TestInotifyCloseSlightlyLaterWithWatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create watcher")
 	}
-	w.Add(testDir)
+	w.AddRaw(testDir)
 
 	// Wait until readEvents has reached unix.Read, and Close.
 	<-time.After(50 * time.Millisecond)
@@ -73,7 +73,7 @@ func TestInotifyCloseAfterRead(t *testing.T) {
 		t.Fatalf("Failed to create watcher")
 	}
 
-	err = w.Add(testDir)
+	err = w.AddRaw(testDir)
 	if err != nil {
 		t.Fatalf("Failed to add .")
 	}
@@ -120,7 +120,7 @@ func TestInotifyCloseCreate(t *testing.T) {
 	}
 	defer w.Close()
 
-	err = w.Add(testDir)
+	err = w.AddRaw(testDir)
 	if err != nil {
 		t.Fatalf("Failed to add testDir: %v", err)
 	}
@@ -148,7 +148,7 @@ func TestInotifyCloseCreate(t *testing.T) {
 	}
 
 	<-time.After(50 * time.Millisecond)
-	err = w.Add(testDir)
+	err = w.AddRaw(testDir)
 	if err != nil {
 		t.Fatalf("Error adding testDir again: %v", err)
 	}
@@ -169,7 +169,7 @@ func TestInotifyStress(t *testing.T) {
 	}
 	defer w.Close()
 
-	err = w.Add(testDir)
+	err = w.AddRaw(testDir)
 	if err != nil {
 		t.Fatalf("Failed to add testDir: %v", err)
 	}
@@ -289,7 +289,7 @@ func TestInotifyRemoveTwice(t *testing.T) {
 	}
 	defer w.Close()
 
-	err = w.Add(testFile)
+	err = w.AddRaw(testFile)
 	if err != nil {
 		t.Fatalf("Failed to add testFile: %v", err)
 	}
@@ -331,7 +331,7 @@ func TestInotifyInnerMapLength(t *testing.T) {
 	}
 	defer w.Close()
 
-	err = w.Add(testFile)
+	err = w.AddRaw(testFile)
 	if err != nil {
 		t.Fatalf("Failed to add testFile: %v", err)
 	}
@@ -383,7 +383,7 @@ func TestInotifyOverflow(t *testing.T) {
 			t.Fatalf("Cannot create subdir: %v", err)
 		}
 
-		err = w.Add(testSubdir)
+		err = w.AddRaw(testSubdir)
 		if err != nil {
 			t.Fatalf("Failed to add subdir: %v", err)
 		}

--- a/kqueue.go
+++ b/kqueue.go
@@ -90,8 +90,8 @@ func (w *Watcher) Close() error {
 	return nil
 }
 
-// Add starts watching the named file or directory (non-recursively).
-func (w *Watcher) Add(name string) error {
+// AddRaw starts watching the named file or directory (non-recursively). Symlinks are not implicitly resolved.
+func (w *Watcher) AddRaw(name string) error {
 	w.mu.Lock()
 	w.externalWatches[name] = true
 	w.mu.Unlock()
@@ -189,33 +189,7 @@ func (w *Watcher) addWatch(name string, flags uint32) (string, error) {
 			return "", nil
 		}
 
-		// Follow Symlinks
-		// Unfortunately, Linux can add bogus symlinks to watch list without
-		// issue, and Windows can't do symlinks period (AFAIK). To  maintain
-		// consistency, we will act like everything is fine. There will simply
-		// be no file events for broken symlinks.
-		// Hence the returns of nil on errors.
-		if fi.Mode()&os.ModeSymlink == os.ModeSymlink {
-			name, err = filepath.EvalSymlinks(name)
-			if err != nil {
-				return "", nil
-			}
-
-			w.mu.Lock()
-			_, alreadyWatching = w.watches[name]
-			w.mu.Unlock()
-
-			if alreadyWatching {
-				return name, nil
-			}
-
-			fi, err = os.Lstat(name)
-			if err != nil {
-				return "", nil
-			}
-		}
-
-		watchfd, err = unix.Open(name, openMode, 0700)
+		watchfd, err = unix.Open(name, openMode|unix.O_SYMLINK, 0700)
 		if watchfd == -1 {
 			return "", err
 		}

--- a/windows.go
+++ b/windows.go
@@ -63,8 +63,8 @@ func (w *Watcher) Close() error {
 	return <-ch
 }
 
-// Add starts watching the named file or directory (non-recursively).
-func (w *Watcher) Add(name string) error {
+// AddRaw starts watching the named file or directory (non-recursively). Symlinks are not implicitly resolved.
+func (w *Watcher) AddRaw(name string) error {
 	if w.isClosed {
 		return errors.New("watcher already closed")
 	}


### PR DESCRIPTION
This is a minor† change for #199 which on the surface adds a `AddRaw` method to the public interface which does not resolve symlinks before starting a watch.
 - [x] rewrite existing `Add` methods to be called `AddRaw` and not follow symlinks
 - [x] reimplement a generic `Add` method which uses `filepath.EvalSymlinks(name)` before calling `AddRaw`
 - [x] ~~consider adding atomic symlink update method~~ (separate issue)
 - [x] document

A follow on from this would be to offer a high level interface as mentioned on my initial comment for the issue - this can be tracked in a separate issue+PR.

† this does change the behaviour of `Add` on windows as it didn't follow symlinks (which do exist) before, but now it does