### PR TITLE
Add inotify CLOSE events

### DIFF
--- a/fsnotify.go
+++ b/fsnotify.go
@@ -29,6 +29,8 @@ const (
 	Remove
 	Rename
 	Chmod
+	Update
+	Close
 )
 
 func (op Op) String() string {
@@ -50,6 +52,13 @@ func (op Op) String() string {
 	if op&Chmod == Chmod {
 		buffer.WriteString("|CHMOD")
 	}
+	if op&Update == Update {
+		buffer.WriteString("|UPDATE")
+	}
+	if op&Close == Close {
+		buffer.WriteString("|CLOSE")
+	}
+
 	if buffer.Len() == 0 {
 		return ""
 	}

--- a/inotify.go
+++ b/inotify.go
@@ -96,7 +96,8 @@ func (w *Watcher) Add(name string) error {
 
 	const agnosticEvents = unix.IN_MOVED_TO | unix.IN_MOVED_FROM |
 		unix.IN_CREATE | unix.IN_ATTRIB | unix.IN_MODIFY |
-		unix.IN_MOVE_SELF | unix.IN_DELETE | unix.IN_DELETE_SELF
+		unix.IN_MOVE_SELF | unix.IN_DELETE | unix.IN_DELETE_SELF | unix.IN_CLOSE_WRITE |
+		unix.IN_CLOSE_NOWRITE
 
 	var flags uint32 = agnosticEvents
 
@@ -333,5 +334,12 @@ func newEvent(name string, mask uint32) Event {
 	if mask&unix.IN_ATTRIB == unix.IN_ATTRIB {
 		e.Op |= Chmod
 	}
+	if mask&unix.IN_CLOSE_WRITE == unix.IN_CLOSE_WRITE || mask&unix.IN_MOVED_TO == unix.IN_MOVED_TO {
+		e.Op |= Update
+	}
+	if mask&unix.IN_CLOSE_WRITE == unix.IN_CLOSE_WRITE || mask&unix.IN_CLOSE_NOWRITE == unix.IN_CLOSE_NOWRITE {
+		e.Op |= Close
+	}
+
 	return e
 }


### PR DESCRIPTION
inotify notifies when files have finished being written to. To reliably
detect if a write to a file has finished the event necessary is
CLOSE_WRITE.


#### What does this pull request do?

Adds CLOSE_WRITE and CLOSE_NOWRITE support for linux


#### Where should the reviewer start?


#### How should this be manually tested?

On a Linux machine you can just copy a file into a folder. Close will be triggered even when a file is not changed.

Update will only trigger when a write was recently finished.