### PR TITLE
Add go.mod and go.sum

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/fsnotify/fsnotify
+
+go 1.13
+
+require golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9 h1:L2auWcuQIvxz9xSEqzESnV/QN/gNRXNApHi3fYwl2w0=
+golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
These were made with:
```sh
go mod init
go get
```
This let me run commands like `go test` and `go fmt` when using `go1.13`