### PR TITLE
Add Linux IN_CLOSE_WRITE support

### DIFF
--- a/fsnotify.go
+++ b/fsnotify.go
@@ -29,6 +29,7 @@ const (
 	Remove
 	Rename
 	Chmod
+	CloseWrite
 )
 
 func (op Op) String() string {
@@ -49,6 +50,9 @@ func (op Op) String() string {
 	}
 	if op&Chmod == Chmod {
 		buffer.WriteString("|CHMOD")
+	}
+	if op&CloseWrite == CloseWrite {
+		buffer.WriteString("|CLOSEWRITE")
 	}
 	if buffer.Len() == 0 {
 		return ""

--- a/inotify.go
+++ b/inotify.go
@@ -94,9 +94,15 @@ func (w *Watcher) Add(name string) error {
 		return errors.New("inotify instance already closed")
 	}
 
-	const agnosticEvents = unix.IN_MOVED_TO | unix.IN_MOVED_FROM |
-		unix.IN_CREATE | unix.IN_ATTRIB | unix.IN_MODIFY |
-		unix.IN_MOVE_SELF | unix.IN_DELETE | unix.IN_DELETE_SELF
+	const agnosticEvents = unix.IN_MOVED_TO |
+		unix.IN_MOVED_FROM |
+		unix.IN_CREATE |
+		unix.IN_ATTRIB |
+		unix.IN_MODIFY |
+		unix.IN_MOVE_SELF |
+		unix.IN_DELETE |
+		unix.IN_DELETE_SELF |
+		unix.IN_CLOSE_WRITE
 
 	var flags uint32 = agnosticEvents
 
@@ -332,6 +338,9 @@ func newEvent(name string, mask uint32) Event {
 	}
 	if mask&unix.IN_ATTRIB == unix.IN_ATTRIB {
 		e.Op |= Chmod
+	}
+	if mask&unix.IN_CLOSE_WRITE == unix.IN_CLOSE_WRITE {
+		e.Op |= CloseWrite
 	}
 	return e
 }


### PR DESCRIPTION
#### What does this pull request do?
Adds support for the Linux inotify IN_CLOSE_WRITE event. This is triggered when a file writer/modifier has finished making changes to a file (e.g. if use is monitoring a FTP upload folder, event is fired when a new file has finished being written).

#### Where should the reviewer start?
fsnotify.go has an extra Op flag: CloseWrite
inotify.go has changes that add the IN_CLOSE_WRITE flag.

#### How should this be manually tested?
Run an app monitoring any directory. Open a file for write (e.g. using vim). On file close (:wq in vim) the IN_CLOSE_WRITE event will be triggered.
