### PR TITLE
Fix unsafe pointer conversion

### DIFF
--- a/inotify.go
+++ b/inotify.go
@@ -272,7 +272,7 @@ func (w *Watcher) readEvents() {
 
 			if nameLen > 0 {
 				// Point "bytes" at the first byte of the filename
-				bytes := (*[unix.PathMax]byte)(unsafe.Pointer(&buf[offset+unix.SizeofInotifyEvent]))
+				bytes := (*[unix.PathMax]byte)(unsafe.Pointer(&buf[offset+unix.SizeofInotifyEvent]))[:nameLen:nameLen]
 				// The filename is padded with NULL bytes. TrimRight() gets rid of those.
 				name += "/" + strings.TrimRight(string(bytes[0:nameLen]), "\000")
 			}


### PR DESCRIPTION
#### What does this pull request do?

Fix the following unsafe pointer conversion found using the Go 1.14
`-d=checkptr gcflags` (`go1.14rc1 test -gcflags=all=-d=checkptr -v ./...`)

```
fatal error: checkptr: unsafe pointer conversion

goroutine 68 [running]:
runtime.throw(0x5833e9, 0x23)
	runtime/panic.go:1112 +0x72 fp=0xc00030fba8 sp=0xc00030fb78 pc=0x432a32
runtime.checkptrAlignment(0xc00031f018, 0x544800, 0x1)
	runtime/checkptr.go:18 +0xb7 fp=0xc00030fbd8 sp=0xc00030fba8 pc=0x4063a7
github.com/fsnotify/fsnotify.(*Watcher).readEvents(0xc0002900f0)
	github.com/fsnotify/fsnotify/inotify.go:275 +0x457 fp=0xc00031ffd8 sp=0xc00030fbd8 pc=0x519037
runtime.goexit()
	runtime/asm_amd64.s:1375 +0x1 fp=0xc00031ffe0 sp=0xc00031ffd8 pc=0x463eb1
created by github.com/fsnotify/fsnotify.NewWatcher
	github.com/fsnotify/fsnotify/inotify.go:59 +0x1a5
```

Fixes #330

#### Where should the reviewer start?

See below.

#### How should this be manually tested?

Run tests with `go1.14rc1 test -gcflags=all=-d=checkptr -v ./...` to observe the unsafe pointer conversion error. After applying this PR it should be gone and all tests pass.