### PR TITLE
kqueue: synchronously close fd in Close()

### DIFF
--- a/fsnotify_test.go
+++ b/fsnotify_test.go
@@ -68,3 +68,19 @@ func TestWatcherClose(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestOpenCloseQuickly(t *testing.T) {
+	name := tempMkFile(t, "")
+
+	for i := 0; i < 1000; i++ {
+		w := newWatcher(t)
+		err := w.Add(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = w.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
This makes it possible to create and destroy watchers quickly on macOS (e.g. in
unit tests).

Closes #333