### PR TITLE
removing link for the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,6 @@ func main() {
 
 Please refer to [CONTRIBUTING][] before opening an issue or pull request.
 
-## Example
-
-See [example_test.go](https://github.com/fsnotify/fsnotify/blob/master/example_test.go).
-
 ## FAQ
 
 **When a file is moved to another directory is it still being watched?**


### PR DESCRIPTION
looks like example itself is moved to the readme, the link for the same (which link "https://github.com/fsnotify/fsnotify/blob/master/example_test.go" is not working anymore)

#### What does this pull request do?

remove unnecessary and non-working link from the readme 

#### Where should the reviewer start?


#### How should this be manually tested?

