### PR TITLE
Remove the Example from REAMDE.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,6 @@ func main() {
 
 Please refer to [CONTRIBUTING][] before opening an issue or pull request.
 
-## Example
-
-See [example_test.go](https://github.com/fsnotify/fsnotify/blob/master/example_test.go).
-
 ## FAQ
 
 **When a file is moved to another directory is it still being watched?**


### PR DESCRIPTION
Before this patch, the Example link would 404.

#### What does this pull request do?

This patch remove the whole Example section, as the example file linked has been removed and the example moved to the README by 45d7d09e39ef4ac08d493309fa031790c15bfe8a.

