### PR TITLE
Fix build on Plan 9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ jobs:
           - freebsd
           - ios
           - linux
+          - plan9
           - windows
         goarch:
           - amd64

--- a/kqueue.go
+++ b/kqueue.go
@@ -102,7 +102,7 @@ func (w *Watcher) Add(name string) error {
 	return err
 }
 
-// Remove stops watching the the named file or directory (non-recursively).
+// Remove stops watching the named file or directory (non-recursively).
 func (w *Watcher) Remove(name string) error {
 	name = filepath.Clean(name)
 	w.mu.Lock()

--- a/plan9.go
+++ b/plan9.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build plan9
 // +build plan9
 
 package fsnotify

--- a/plan9.go
+++ b/plan9.go
@@ -1,15 +1,12 @@
-// Copyright 2010 The Go Authors. All rights reserved.
+// Copyright 2020 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build solaris
-// +build solaris
+// +build plan9
 
 package fsnotify
 
-import (
-	"errors"
-)
+import "syscall"
 
 // Watcher watches a set of files, delivering events to a channel.
 type Watcher struct {
@@ -19,20 +16,20 @@ type Watcher struct {
 
 // NewWatcher establishes a new watcher with the underlying OS and begins waiting for events.
 func NewWatcher() (*Watcher, error) {
-	return nil, errors.New("FEN based watcher not yet supported for fsnotify\n")
+	return nil, syscall.EPLAN9
 }
 
 // Close removes all watches and closes the events channel.
 func (w *Watcher) Close() error {
-	return nil
+	return syscall.EPLAN9
 }
 
 // Add starts watching the named file or directory (non-recursively).
 func (w *Watcher) Add(name string) error {
-	return nil
+	return syscall.EPLAN9
 }
 
 // Remove stops watching the named file or directory (non-recursively).
 func (w *Watcher) Remove(name string) error {
-	return nil
+	return syscall.EPLAN9
 }

--- a/windows.go
+++ b/windows.go
@@ -92,7 +92,7 @@ func (w *Watcher) Add(name string) error {
 	return <-in.reply
 }
 
-// Remove stops watching the the named file or directory (non-recursively).
+// Remove stops watching the named file or directory (non-recursively).
 func (w *Watcher) Remove(name string) error {
 	in := &input{
 		op:    opRemoveWatch,


### PR DESCRIPTION
This fixes build for programs that import fsnotify but fsnotify is not
absolutely necessary for the program to be useful.

#### What does this pull request do?

Fixes build on Plan 9.

#### Where should the reviewer start?

plan9.go

#### How should this be manually tested?

`GOOS=plan9 go build`