### PR TITLE
TravisCI: bump Go versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ language: go
 
 go:
   - "stable"
-  - "1.11.x"
-  - "1.10.x"
-  - "1.9.x"
+  - "1.15.x"
+  - "1.14.x"
+  - "1.13.x"
 
 matrix:
   include:


### PR DESCRIPTION
This fixes the CI. Builds were failing because `go.mod` file wasn't
being used on older Go versions on macOS. This led to using the wrong
version of `golang.org/x/sys/unix`. See for example:
https://travis-ci.org/github/fsnotify/fsnotify/builds/742594311