### PR TITLE
add getters for events and errors so that fsnotify can be more easily mocked

### DIFF
--- a/fsnotify.go
+++ b/fsnotify.go
@@ -13,6 +13,17 @@ import (
 	"fmt"
 )
 
+
+// GetEvents returns a channel of events.
+func (w *Watcher) GetEvents() <-chan Event {
+	return w.Events
+}
+
+// GetErrors returns a channel of errors.
+func (w *Watcher) GetErrors() <-chan error {
+	return w.Errors
+}
+
 // Event represents a single file system notification.
 type Event struct {
 	Name string // Relative path to the file or directory.

--- a/fsnotify_test.go
+++ b/fsnotify_test.go
@@ -12,6 +12,17 @@ import (
 	"time"
 )
 
+type watcher interface {
+	Close() error
+	Add(string) error
+	Remove(string) error
+	GetEvents() <-chan Event
+	GetErrors() <-chan error
+}
+
+// ensure that the Watcher meets the watcher interface.
+var _ watcher = &Watcher{}
+
 func TestEventStringWithValue(t *testing.T) {
 	for opMask, expectedString := range map[Op]string{
 		Chmod | Create: `"/usr/someFile": CREATE|CHMOD`,


### PR DESCRIPTION
#### What does this pull request do?
This PR adds GetEvents and GetErrors methods . This is useful so that the watcher used in fsnotify can be more easily mocked. This does not break the existing interface it only adds two new methods.


#### Where should the reviewer start?
Only two methods that should be reviewable by inspection. A compile time test is added to fsnofify_test.go that ensures the new interface is implemented.

#### How should this be manually tested?
This should not be necessary.
