### PR TITLE
provide polling plan9 support

### DIFF
--- a/fsnotify.go
+++ b/fsnotify.go
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !plan9
-
 // Package fsnotify provides a platform-independent interface for file system notifications.
 package fsnotify
 

--- a/qid.go
+++ b/qid.go
@@ -1,0 +1,120 @@
+// Copyright 2010 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build plan9
+
+package fsnotify
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+	"time"
+)
+
+func dirStat(s string) (*syscall.Dir, error) {
+	fi, err := os.Stat(s)
+	if err != nil {
+		return nil, os.ErrNotExist
+	}
+	d, ok := fi.Sys().(*syscall.Dir)
+	if !ok || d == nil {
+		return nil, fmt.Errorf("could not cast %s to dir", s)
+	}
+	return d, nil
+}
+
+// Watcher watches a set of files, delivering events to a channel.
+type Watcher struct {
+	Events chan Event
+	Errors chan error
+
+	add    chan string
+	remove chan string
+	exit   chan struct{}
+}
+
+// NewWatcher establishes a new watcher with the underlying OS and begins waiting for events.
+func NewWatcher() (*Watcher, error) {
+	w := &Watcher{
+		Events: make(chan Event),
+		Errors: make(chan error),
+		add:    make(chan string),
+		remove: make(chan string),
+		exit:   make(chan struct{}),
+	}
+	go w.watch()
+	return w, nil
+}
+
+func (w *Watcher) watch() {
+	state := make(map[string]*syscall.Dir)
+	tick := time.Tick(time.Second)
+	for {
+		select {
+		case s := <-w.add:
+			d, err := dirStat(s)
+			if err != nil {
+				w.Errors <- err
+				continue
+			}
+			state[s] = d
+		case s := <-w.remove:
+			delete(state, s)
+		case <-tick:
+			for s, old := range state {
+				d, err := dirStat(s)
+				switch {
+				case err == os.ErrNotExist:
+					w.Events <- Event{s, Remove}
+					continue
+				case err != nil:
+					w.Errors <- err
+					continue
+				}
+				if d.Qid.Path != old.Qid.Path {
+					state[s] = d
+					w.Events <- Event{s, Create}
+					continue
+				}
+				switch {
+				case d.Mode != old.Mode:
+					fallthrough
+				case d.Uid != old.Uid:
+					fallthrough
+				case d.Gid != old.Gid:
+					state[s] = d
+					w.Events <- Event{s, Chmod}
+					continue
+				}
+				if d.Qid.Vers != old.Qid.Vers {
+					state[s] = d
+					w.Events <- Event{s, Write}
+				}
+			}
+		case <-w.exit:
+			return
+		}
+	}
+}
+
+// Add starts watching the named file or directory (non-recursively).
+func (w *Watcher) Add(name string) error {
+	w.add <- name
+	return nil
+}
+
+// Remove stops watching the named file or directory (non-recursively).
+func (w *Watcher) Remove(name string) error {
+	w.remove <- name
+	return nil
+}
+
+// Close removes all watches and closes the events channel.
+func (w *Watcher) Close() error {
+	w.exit <- struct{}{}
+	close(w.Events)
+	close(w.Errors)
+	return nil
+}

--- a/qid_test.go
+++ b/qid_test.go
@@ -1,0 +1,45 @@
+// Copyright 2010 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build plan9
+
+package fsnotify
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func TestWatcher(t *testing.T) {
+	f, err := os.CreateTemp("", "fsnotify-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	w, _ := NewWatcher()
+	w.Add(f.Name())
+	//Dont modify before the watch goroutine can get a version of it
+	time.Sleep(2 * time.Second)
+	f.Write([]byte("Hello"))
+	e := <-w.Events
+	if e.Op != Write {
+		t.Fatalf("expected Write op, got %v", e)
+	}
+	os.Chmod(f.Name(), 0777)
+	e = <-w.Events
+	if e.Op != Chmod {
+		t.Fatalf("execpted Chmod op, got %v", e)
+	}
+	os.Remove(f.Name())
+	e = <-w.Events
+	if e.Op != Remove {
+		t.Fatalf("expected Remove op, got %v", e)
+	}
+	os.Create(f.Name())
+	e = <-w.Events
+	if e.Op != Create {
+		t.Fatalf("expected Create op, got %v", e)
+	}
+}


### PR DESCRIPTION
#### What does this pull request do?

Provides a very basic polling implementation for plan9. Its not fantastic but should serve the purpose for when fsnotify
is included and not used, or if its used very minimally.

#### Where should the reviewer start?

qid.go

#### How should this be manually tested?

`GOOS=plan9 go build`


`go test`
on a plan9/9front machine
