### PR TITLE
Fix: Update watch paths when renaming directories with sub-watches on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+* Windows: Fixed persistence of original path-name in watches within renamed directory (#259, #243)
+
 ## v1.4.7 / 2018-01-09
 
 * BSD/macOS: Fix possible deadlock on closing the watcher on kqueue (thanks @nhooyr and @glycerine)

--- a/windows.go
+++ b/windows.go
@@ -468,9 +468,11 @@ func (w *Watcher) readEvents() {
 
 				// update saved path of all sub-watches
 				oldFullName := filepath.Join(watch.path, watch.rename)
-				for _, otherWatch := range w.watches {
-					if strings.HasPrefix(otherWatch.path, oldFullName) {
-						otherWatch.path = filepath.Join(watch.path, strings.TrimPrefix(otherWatch.path, oldFullName))
+				for _, watchMap := range w.watches {
+					for _, otherWatch := range watchMap {
+						if strings.HasPrefix(otherWatch.path, oldFullName) {
+							otherWatch.path = filepath.Join(fullname, strings.TrimPrefix(otherWatch.path, oldFullName))
+						}
 					}
 				}
 


### PR DESCRIPTION
#### What does this pull request do?

Fixes #259
Fixes #243 
