### PR TITLE
Fix: Update watch paths when renaming directories with sub-watches on Windows 

### DIFF
--- a/helpers_test.go
+++ b/helpers_test.go
@@ -411,6 +411,12 @@ func newEvents(t *testing.T, s string) Events {
 	if e, ok := events[runtime.GOOS]; ok {
 		return e
 	}
+	switch runtime.GOOS {
+	case "freebsd", "netbsd", "openbsd", "dragonfly", "darwin":
+		if e, ok := events["kqueue"]; ok {
+			return e
+		}
+	}
 	return events[""]
 }
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -5,8 +5,6 @@ package fsnotify
 
 import (
 	"fmt"
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -165,6 +163,36 @@ func TestWatchRename(t *testing.T) {
 				create /renamed
 			windows:
 				create /renamed
+		`},
+
+		{"rename watched directory", func(t *testing.T, w *Watcher, tmp string) {
+			addWatch(t, w, tmp)
+
+			dir := filepath.Join(tmp, "dir")
+			mkdir(t, dir)
+			addWatch(t, w, dir)
+
+			mv(t, dir, tmp, "dir-renamed")
+			touch(t, tmp, "dir-renamed/file")
+		}, `
+			CREATE   "/dir"           # mkdir
+			RENAME   "/dir"           # mv
+			CREATE   "/dir-renamed"
+			RENAME   "/dir"
+			CREATE   "/dir/file"      # touch
+
+			windows:
+				CREATE       "/dir"                 # mkdir
+				RENAME       "/dir"                 # mv
+				CREATE       "/dir-renamed"
+				CREATE       "/dir-renamed/file"    # touch
+
+			# TODO: no results for the touch; this is probably a bug; windows
+			# was fixed in #370.
+			kqueue:
+				CREATE               "/dir"           # mkdir
+				CREATE               "/dir-renamed"   # mv
+				REMOVE|RENAME        "/dir"
 		`},
 	}
 
@@ -474,57 +502,4 @@ func TestRemove(t *testing.T) {
 			w.Close()
 		}
 	})
-}
-
-func TestMoveWatchedDirectory(t *testing.T) {
-	testDir := tempMkdir(t)
-	defer os.RemoveAll(testDir)
-
-	watcher := newWatcher(t)
-
-	// event recording
-	var events []Event
-	go func() {
-		for {
-			event, ok := <-watcher.Events
-			if !ok {
-				return
-			}
-			events = append(events, event)
-		}
-	}()
-
-	addWatch(t, watcher, testDir)
-
-	dir1 := filepath.Join(testDir, "dir")
-	dir2 := filepath.Join(testDir, "dir2")
-
-	if err := os.Mkdir(dir1, 0o775); err != nil {
-		t.Fatal(err)
-	}
-	time.Sleep(10 * time.Millisecond)
-	addWatch(t, watcher, dir1)
-	if err := os.Rename(dir1, dir2); err != nil {
-		t.Fatal(err)
-	}
-
-	time.Sleep(10 * time.Millisecond)
-	err := ioutil.WriteFile(filepath.Join(dir2, "file.ext"), []byte(""), 0o664)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if err := watcher.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	time.Sleep(10 * time.Millisecond)
-	if len(events) != 4 {
-		t.Fatalf("Expected 4 events. Got: %d", len(events))
-	}
-
-	expectedSuffix := filepath.Join("dir2", "file.ext")
-	if !strings.HasSuffix(events[3].Name, expectedSuffix) {
-		t.Fatalf("Expected suffix %s, Got: %s", expectedSuffix, events[3].Name)
-	}
 }

--- a/windows.go
+++ b/windows.go
@@ -504,9 +504,11 @@ func (w *Watcher) readEvents() {
 
 				// update saved path of all sub-watches
 				oldFullName := filepath.Join(watch.path, watch.rename)
-				for _, otherWatch := range w.watches {
-					if strings.HasPrefix(otherWatch.path, oldFullName) {
-						otherWatch.path = filepath.Join(watch.path, strings.TrimPrefix(otherWatch.path, oldFullName))
+				for _, watchMap := range w.watches {
+					for _, otherWatch := range watchMap {
+						if strings.HasPrefix(otherWatch.path, oldFullName) {
+							otherWatch.path = filepath.Join(fullname, strings.TrimPrefix(otherWatch.path, oldFullName))
+						}
 					}
 				}
 

--- a/windows.go
+++ b/windows.go
@@ -501,9 +501,9 @@ func (w *Watcher) readEvents() {
 			case syscall.FILE_ACTION_RENAMED_OLD_NAME:
 				watch.rename = name
 			case syscall.FILE_ACTION_RENAMED_NEW_NAME:
-
-				// update saved path of all sub-watches
+				// Update saved path of all sub-watches.
 				oldFullName := filepath.Join(watch.path, watch.rename)
+				w.mu.Lock()
 				for _, watchMap := range w.watches {
 					for _, otherWatch := range watchMap {
 						if strings.HasPrefix(otherWatch.path, oldFullName) {
@@ -511,6 +511,7 @@ func (w *Watcher) readEvents() {
 						}
 					}
 				}
+				w.mu.Unlock()
 
 				if watch.names[watch.rename] != 0 {
 					watch.names[name] |= watch.names[watch.rename]

--- a/windows.go
+++ b/windows.go
@@ -502,12 +502,12 @@ func (w *Watcher) readEvents() {
 				watch.rename = name
 			case syscall.FILE_ACTION_RENAMED_NEW_NAME:
 				// Update saved path of all sub-watches.
-				oldFullName := filepath.Join(watch.path, watch.rename)
+				old := filepath.Join(watch.path, watch.rename)
 				w.mu.Lock()
 				for _, watchMap := range w.watches {
-					for _, otherWatch := range watchMap {
-						if strings.HasPrefix(otherWatch.path, oldFullName) {
-							otherWatch.path = filepath.Join(fullname, strings.TrimPrefix(otherWatch.path, oldFullName))
+					for _, ww := range watchMap {
+						if strings.HasPrefix(ww.path, old) {
+							ww.path = filepath.Join(fullname, strings.TrimPrefix(ww.path, old))
 						}
 					}
 				}


### PR DESCRIPTION
#### What does this pull request do?

Fixes #259
Fixes #243 
