### PR TITLE
Update x/sys to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/fsnotify/fsnotify
 
 go 1.13
 
-require golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9
+require golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9 h1:L2auWcuQIvxz9xSEqzESnV/QN/gNRXNApHi3fYwl2w0=
-golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c h1:F1jZWGFhYfh0Ci55sIpILtKKK8p3i2/krTr0H1rg74I=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
#### What does this pull request do?

Upgrades x/sys to the latest revision as of today.

#### Where should the reviewer start?

This update appears to break test `(macos-latest, 1.11)`.
#371 will require an update to x/sys and exhibits the same test failure.
This PR demonstrates that the breakage is from x/sys, not the content of #371.

I don't know if it's safe to drop support for 1.11, if this represents a bug somehow introduced into x/sys/unix, or something else.

#### How should this be manually tested?

The important test failure is automated with GitHub actions.