### PR TITLE
Drop support/testing for Go 1.11 and earlier

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,10 +18,6 @@ jobs:
           - '1.14'
           - '1.13'
           - '1.12'
-          - '1.11'
-        # omitting these as they fail on macos+ubuntu with "kqueue.go:18:2: cannot find package "golang.org/x/sys/unix" in any of:"
-        # - '1.10'
-        # - '1.9'
     runs-on: ${{ matrix.os }}
     steps:
       - name: setup Go


### PR DESCRIPTION
#### What does this pull request do?

Remove 1.11 (and comments about 1.10 and 1.9) from the the GitHub actions testing matrix.

#### Where should the reviewer start?

See #379 where the fact that 1.11 is no longer supported becomes an issue for pulling in new features in the latest versions of x/sys/unix.

#### How should this be manually tested?

N/A