### PR TITLE
Lint

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,6 @@ jobs:
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
-        continue-on-error: true
         with:
           version: v1.41.1
           # this is here as a workaround for https://github.com/golangci/golangci-lint-action/issues/244

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,6 @@ jobs:
           - '1.15'
           - '1.14'
           - '1.13'
-          - '1.12'
     runs-on: ${{ matrix.os }}
     steps:
       - name: setup Go

--- a/fsnotify.go
+++ b/fsnotify.go
@@ -17,6 +17,9 @@ import (
 // ErrWatchDoesNotExist is returned by `Watcher.Remove(name)` when the given name is not monitored by the watcher
 var ErrWatchDoesNotExist = errors.New("Watch does not exist")
 
+// ErrWatcherClosed is returned by `Watcher.Remove(name)` by methods attempting to modify the state of a closed watcher
+var ErrWatcherClosed = errors.New("Watcher is closed")
+
 // Event represents a single file system notification.
 type Event struct {
 	Name string // Relative path to the file or directory.

--- a/fsnotify.go
+++ b/fsnotify.go
@@ -14,6 +14,9 @@ import (
 	"fmt"
 )
 
+// ErrWatchDoesNotExist is returned by `Watcher.Remove(name)` when the given name is not monitored by the watcher
+var ErrWatchDoesNotExist = errors.New("Watch does not exist")
+
 // Event represents a single file system notification.
 type Event struct {
 	Name string // Relative path to the file or directory.

--- a/inotify.go
+++ b/inotify.go
@@ -138,7 +138,7 @@ func (w *Watcher) Remove(name string) error {
 
 	// Remove it from inotify.
 	if !ok {
-		return fmt.Errorf("can't remove non-existent inotify watch for: %s", name)
+		return fmt.Errorf("can't remove watch: %w: %s", ErrWatchDoesNotExist, name)
 	}
 
 	// We successfully removed the watch if InotifyRmWatch doesn't return an

--- a/inotify.go
+++ b/inotify.go
@@ -71,6 +71,8 @@ func (w *Watcher) isClosed() bool {
 }
 
 // Close removes all watches and closes the events channel.
+// XXX: this can fail on inotify with "broken pipe" and "bad file descriptor", it will show up in test runs fairly
+// frequently, e.g. `go test -run=TestRemoveWithClose -count=100`
 func (w *Watcher) Close() error {
 	if w.isClosed() {
 		return nil

--- a/inotify.go
+++ b/inotify.go
@@ -80,7 +80,9 @@ func (w *Watcher) Close() error {
 	close(w.done)
 
 	// Wake up goroutine
-	w.poller.wake()
+	if err := w.poller.wake(); err != nil {
+		return err
+	}
 
 	// Wait for goroutine to close
 	<-w.doneResp

--- a/inotify_poller.go
+++ b/inotify_poller.go
@@ -123,6 +123,7 @@ func (poller *fdPoller) wait() (bool, error) {
 				if event.Events&unix.EPOLLHUP != 0 {
 					// Write pipe descriptor was closed, by us. This means we're closing down the
 					// watcher, and we should wake up.
+					continue
 				}
 				if event.Events&unix.EPOLLERR != 0 {
 					// If an error is waiting on the pipe file descriptor.

--- a/integration_test.go
+++ b/integration_test.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path"
 	"path/filepath"
 	"runtime"
@@ -149,7 +148,7 @@ func TestFsnotifyMultipleOperations(t *testing.T) {
 
 	time.Sleep(50 * time.Millisecond) // give system time to sync write change before delete
 
-	if err := testRename(testFile, testFileRenamed); err != nil {
+	if err := os.Rename(testFile, testFileRenamed); err != nil {
 		t.Fatalf("rename failed: %s", err)
 	}
 
@@ -680,7 +679,7 @@ func TestFsnotifyRename(t *testing.T) {
 	// Add a watch for testFile
 	addWatch(t, watcher, testFile)
 
-	if err := testRename(testFile, testFileRenamed); err != nil {
+	if err := os.Rename(testFile, testFileRenamed); err != nil {
 		t.Fatalf("rename failed: %s", err)
 	}
 
@@ -758,7 +757,7 @@ func TestFsnotifyRenameToCreate(t *testing.T) {
 	}
 	f.Close()
 
-	if err := testRename(testFile, testFileRenamed); err != nil {
+	if err := os.Rename(testFile, testFileRenamed); err != nil {
 		t.Fatalf("rename failed: %s", err)
 	}
 
@@ -850,7 +849,7 @@ func TestFsnotifyRenameToOverwrite(t *testing.T) {
 	}
 	f.Close()
 
-	if err := testRename(testFile, testFileRenamed); err != nil {
+	if err := os.Rename(testFile, testFileRenamed); err != nil {
 		t.Fatalf("rename failed: %s", err)
 	}
 
@@ -1324,15 +1323,5 @@ func TestRemoveWithClose(t *testing.T) {
 	defer close(stopC)
 	if err := <-errC; err != nil {
 		t.Fatalf("Expected no error on Close, got %v.", err)
-	}
-}
-
-func testRename(file1, file2 string) error {
-	switch runtime.GOOS {
-	case "windows", "plan9":
-		return os.Rename(file1, file2)
-	default:
-		cmd := exec.Command("mv", file1, file2)
-		return cmd.Run()
 	}
 }

--- a/integration_test.go
+++ b/integration_test.go
@@ -128,7 +128,7 @@ func TestFsnotifyMultipleOperations(t *testing.T) {
 	// Create a file
 	// This should add at least one event to the fsnotify event queue
 	var f *os.File
-	f, err := os.OpenFile(testFile, os.O_WRONLY|os.O_CREATE, 0666)
+	f, err := os.Create(testFile)
 	if err != nil {
 		t.Fatalf("creating test file failed: %s", err)
 	}
@@ -154,7 +154,7 @@ func TestFsnotifyMultipleOperations(t *testing.T) {
 	}
 
 	// Modify the file outside of the watched dir
-	f, err = os.Open(testFileRenamed)
+	f, err = os.OpenFile(testFileRenamed, os.O_RDWR, 0)
 	if err != nil {
 		t.Fatalf("open test renamed file failed: %s", err)
 	}

--- a/integration_test.go
+++ b/integration_test.go
@@ -1254,14 +1254,14 @@ func TestConcurrentRemovalOfWatch(t *testing.T) {
 		done <- true
 	}()
 
-	deadline := time.NewTimer(1 * time.Second)
+	deadline := time.After(1 * time.Second)
 	for i := 0; i < 2; i++ {
 		select {
 		case <-done:
 			continue
 		case err := <-errs:
 			t.Fatalf("error: %s", err)
-		case <-deadline.C:
+		case <-deadline:
 			t.Fatal("deadline exceeded")
 		}
 	}

--- a/integration_test.go
+++ b/integration_test.go
@@ -1306,6 +1306,7 @@ func TestRemoveWithClose(t *testing.T) {
 	if err := watcher.Add(testDir); err != nil {
 		t.Fatalf("Expected no error on Add, got %v", err)
 	}
+
 	startC, stopC := make(chan struct{}), make(chan struct{})
 	errC := make(chan error)
 	go func() {

--- a/windows.go
+++ b/windows.go
@@ -300,7 +300,7 @@ func (w *Watcher) remWatch(pathname string) error {
 	watch := w.watches.get(ino)
 	w.mu.Unlock()
 	if watch == nil {
-		return fmt.Errorf("can't remove non-existent watch for: %s", pathname)
+		return fmt.Errorf("can't remove watch: %w: %s", ErrWatchDoesNotExist, pathname)
 	}
 	if pathname == dir {
 		w.sendEvent(watch.path, watch.mask&sysFSIGNORED)


### PR DESCRIPTION
* remove linting issues
* require future PRs to not introduce any linting issues
* fix tests on Windows which were denied access when trying to write to a file opened for only reading
* remove testRename as an external call isn't necessary

_**edit:** crudely fixing the lint issues shows a lot of returned errors which is making this PR grow. The lint golangci-lint job doesn't show everything at once so can be a game of whack-a-mole. Changing PR to draft until everything is sorted out_