### PR TITLE
Remove `retract` directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,5 +3,3 @@ module github.com/fsnotify/fsnotify
 go 1.13
 
 require golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c
-
-retract v1.5.0


### PR DESCRIPTION
#### What does this pull request do?

Remove `retract` directive.

The `retract` directive only works Go >= 1.16. The versions under that can't recognize the directive and cause an error. (e.g. https://github.com/fsnotify/fsnotify/runs/3414923756)

So removed the directive to work builds.

#### Where should the reviewer start?

Please see CI passes.

#### How should this be manually tested?

No need.
