### PR TITLE
Don't set `poller.fd` twice in `newFdPoller`

### DIFF
--- a/inotify_poller.go
+++ b/inotify_poller.go
@@ -38,7 +38,6 @@ func newFdPoller(fd int) (*fdPoller, error) {
 			poller.close()
 		}
 	}()
-	poller.fd = fd
 
 	// Create epoll fd
 	poller.epfd, errno = unix.EpollCreate1(unix.EPOLL_CLOEXEC)


### PR DESCRIPTION
In `newEmptyPoller` when creating the `poller` using `newEmptyPoller(fd)`, the
`fd` field is already set. There is no need to set it again.