### PR TITLE
pass testing.T explicitly to the anonymous func

### DIFF
--- a/inotify_poller_test.go
+++ b/inotify_poller_test.go
@@ -174,19 +174,19 @@ func TestPollerConcurrent(t *testing.T) {
 	oks := make(chan bool)
 	live := make(chan bool)
 	defer close(live)
-	go func() {
+	go func(tb testing.TB) {
 		defer close(oks)
 		for {
 			ok, err := poller.wait()
 			if err != nil {
-				t.Fatalf("poller failed: %v", err)
+				tb.Fatalf("poller failed: %v", err)
 			}
 			oks <- ok
 			if !<-live {
 				return
 			}
 		}
-	}()
+	}(t)
 
 	// Try a write
 	select {

--- a/inotify_test.go
+++ b/inotify_test.go
@@ -336,11 +336,11 @@ func TestInotifyInnerMapLength(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to add testFile: %v", err)
 	}
-	go func() {
+	go func(tb testing.TB) {
 		for err := range w.Errors {
-			t.Fatalf("error received: %s", err)
+			tb.Fatalf("error received: %s", err)
 		}
-	}()
+	}(t)
 
 	err = os.Remove(testFile)
 	if err != nil {

--- a/integration_test.go
+++ b/integration_test.go
@@ -75,11 +75,11 @@ func TestFsnotifyMultipleOperations(t *testing.T) {
 	watcher := newWatcher(t)
 
 	// Receive errors on the error channel on a separate goroutine
-	go func() {
+	go func(tb testing.TB) {
 		for err := range watcher.Errors {
-			t.Fatalf("error received: %s", err)
+			tb.Fatalf("error received: %s", err)
 		}
-	}()
+	}(t)
 
 	// Create directory to watch
 	testDir := tempMkdir(t)
@@ -837,14 +837,14 @@ func TestRemovalOfWatch(t *testing.T) {
 		t.Fatalf("Could not remove the watch: %v\n", err)
 	}
 
-	go func() {
+	go func(tb testing.TB) {
 		select {
 		case ev := <-watcher.Events:
-			t.Fatalf("We received event: %v\n", ev)
+			tb.Fatalf("We received event: %v\n", ev)
 		case <-time.After(500 * time.Millisecond):
-			t.Log("No event received, as expected.")
+			tb.Log("No event received, as expected.")
 		}
-	}()
+	}(t)
 
 	time.Sleep(200 * time.Millisecond)
 	// Modify the file outside of the watched dir


### PR DESCRIPTION
#### What does this pull request do?

Passes testing.T explicitly to the anonymous function run as a goroutine. By this change, `go vet` succeeds.
Fixes https://github.com/fsnotify/fsnotify/issues/412

#### Where should the reviewer start?

Read https://github.com/fsnotify/fsnotify/issues/412 to understand the problem and make sure testing.T is correctly used.

#### How should this be manually tested?

Run `go vet` locally.