### PR TITLE
Re-enable tests for PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,7 @@
 name: test
-on: [push]
+on:
+  push:
+  pull_request:
 jobs:
   test:
     strategy:


### PR DESCRIPTION
I imagine that disabling testing for PRs may have been needed to unbreak things while cleaning up the older releases in the test matrix.
It would be good to re-enable tests on PRs.