### PR TITLE
fix go vet warnings: call to (*T).Fatalf from a non-test goroutine

### DIFF
--- a/inotify_poller_test.go
+++ b/inotify_poller_test.go
@@ -179,7 +179,7 @@ func TestPollerConcurrent(t *testing.T) {
 		for {
 			ok, err := poller.wait()
 			if err != nil {
-				t.Fatalf("poller failed: %v", err)
+				t.Errorf("poller failed: %v", err)
 			}
 			oks <- ok
 			if !<-live {
@@ -227,4 +227,8 @@ func TestPollerConcurrent(t *testing.T) {
 		t.Fatalf("expected true")
 	}
 	tfd.get(t)
+
+	// wait for all goroutines for finish.
+	live <- false
+	<-oks
 }

--- a/inotify_test.go
+++ b/inotify_test.go
@@ -330,15 +330,17 @@ func TestInotifyInnerMapLength(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create watcher: %v", err)
 	}
-	defer w.Close()
 
 	err = w.Add(testFile)
 	if err != nil {
 		t.Fatalf("Failed to add testFile: %v", err)
 	}
+	var wg sync.WaitGroup
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		for err := range w.Errors {
-			t.Fatalf("error received: %s", err)
+			t.Errorf("error received: %s", err)
 		}
 	}()
 
@@ -357,6 +359,9 @@ func TestInotifyInnerMapLength(t *testing.T) {
 	if len(w.paths) != 0 {
 		t.Fatalf("Expected paths len is 0, but got: %d, %v", len(w.paths), w.paths)
 	}
+
+	w.Close()
+	wg.Wait()
 }
 
 func TestInotifyOverflow(t *testing.T) {


### PR DESCRIPTION
#### What does this pull request do?

fixes `go vet` warnings:

```
./inotify_poller_test.go:182:5: call to (*T).Fatalf from a non-test goroutine
./inotify_test.go:341:4: call to (*T).Fatalf from a non-test goroutine
./integration_test.go:80:4: call to (*T).Fatalf from a non-test goroutine
./integration_test.go:843:4: call to (*T).Fatalf from a non-test goroutine
```

closes https://github.com/fsnotify/fsnotify/issues/412

#### Where should the reviewer start?

Read https://github.com/fsnotify/fsnotify/issues/412 and https://github.com/fsnotify/fsnotify/pull/414 to understand the problem and make sure `testing.T` is correctly used.

#### How should this be manually tested?

Run `go vet` locally.