### PR TITLE
Add raw, os-dependent op bitmask to Event

### DIFF
--- a/fsnotify.go
+++ b/fsnotify.go
@@ -16,8 +16,9 @@ import (
 
 // Event represents a single file system notification.
 type Event struct {
-	Name string // Relative path to the file or directory.
-	Op   Op     // File operation that triggered the event.
+	Name  string // Relative path to the file or directory.
+	Op    Op     // File operation that triggered the event.
+	RawOp uint32 // Unprocessed event bitmask as returned by the OS.
 }
 
 // Op describes a set of file operations.

--- a/inotify.go
+++ b/inotify.go
@@ -318,7 +318,10 @@ func (e *Event) ignoreLinux(mask uint32) bool {
 
 // newEvent returns an platform-independent Event based on an inotify mask.
 func newEvent(name string, mask uint32) Event {
-	e := Event{Name: name}
+	e := Event{
+		Name:  name,
+		RawOp: mask,
+	}
 	if mask&unix.IN_CREATE == unix.IN_CREATE || mask&unix.IN_MOVED_TO == unix.IN_MOVED_TO {
 		e.Op |= Create
 	}


### PR DESCRIPTION
#### What does this pull request do?

Adds the raw, unprocessed event bitmask to the `Event` struct.

I have seen a couple of PRs closed when adding events that were not cross platform, referring to a [future lower-level API](https://github.com/fsnotify/fsnotify/issues/173), which in no doubt is the best way forward. However, building that API seems to be a long-term effort.

In my view there are use cases that would benefit from using fsnotify in a way that is not completely cross platform, and willing to forfeit validation on its side For example:
- Small projects which are targeted to run in a particular OS
- Larger projects which are willing to deal with platform-dependent code in their side

With this use cases in mind, I think there could be some value in having the raw, os-dependent op bitmask reported in the event, in a non-intrusive way. Callers should be aware that this bitmask is heavily OS-dependent, and act accordingly in their side instead.

#### Where should the reviewer start?

The whole PR should fit in the viewport :)

#### How should this be manually tested?

I don't think there are any tests needed, but if desired, I can add a few integration tests build-tagged for unix and asserting the reported `Event.RawOp`.