### PR TITLE
CI: fix golangci-lint warnings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,5 @@ jobs:
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
-        continue-on-error: true
         with:
           version: latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,25 +47,11 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - name: setup Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: '1.17'
-
       - name: checkout
         uses: actions/checkout@v2
-
-      - name: gofmt
-        run: |
-          test -z "$(gofmt -s -d . | tee /dev/stderr)"
-
-      - name: vet
-        run: |
-          go vet ./...
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         continue-on-error: true
         with:
           version: latest
-          skip-go-installation: true

--- a/fsnotify_test.go
+++ b/fsnotify_test.go
@@ -52,20 +52,15 @@ func TestWatcherClose(t *testing.T) {
 
 	name := tempMkFile(t, "")
 	w := newWatcher(t)
-	err := w.Add(name)
-	if err != nil {
-		t.Fatal(err)
-	}
+	addWatch(t, w, name)
 
-	err = os.Remove(name)
-	if err != nil {
+	if err := os.Remove(name); err != nil {
 		t.Fatal(err)
 	}
 	// Allow the watcher to receive the event.
 	time.Sleep(time.Millisecond * 100)
 
-	err = w.Close()
-	if err != nil {
+	if err := w.Close(); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/inotify.go
+++ b/inotify.go
@@ -80,7 +80,9 @@ func (w *Watcher) Close() error {
 	close(w.done)
 
 	// Wake up goroutine
-	w.poller.wake()
+	if err := w.poller.wake(); err != nil {
+		return fmt.Errorf("poller.wake failed: %w", err)
+	}
 
 	// Wait for goroutine to close
 	<-w.doneResp

--- a/inotify_poller.go
+++ b/inotify_poller.go
@@ -119,10 +119,6 @@ func (poller *fdPoller) wait() (bool, error) {
 				}
 			}
 			if event.Fd == int32(poller.pipe[0]) {
-				if event.Events&unix.EPOLLHUP != 0 {
-					// Write pipe descriptor was closed, by us. This means we're closing down the
-					// watcher, and we should wake up.
-				}
 				if event.Events&unix.EPOLLERR != 0 {
 					// If an error is waiting on the pipe file descriptor.
 					// This is an absolute mystery, and should never ever happen.

--- a/inotify_test.go
+++ b/inotify_test.go
@@ -131,7 +131,7 @@ func TestInotifyCloseCreate(t *testing.T) {
 	}
 	h.Close()
 	select {
-	case _ = <-w.Events:
+	case <-w.Events:
 	case err := <-w.Errors:
 		t.Fatalf("Error from watcher: %v", err)
 	case <-time.After(50 * time.Millisecond):
@@ -348,7 +348,7 @@ func TestInotifyInnerMapLength(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to remove testFile: %v", err)
 	}
-	_ = <-w.Events                      // consume Remove event
+	<-w.Events                          // consume Remove event
 	<-time.After(50 * time.Millisecond) // wait IN_IGNORE propagated
 
 	w.mu.Lock()

--- a/inotify_test.go
+++ b/inotify_test.go
@@ -143,7 +143,6 @@ func TestInotifyCloseCreate(t *testing.T) {
 	// Now we try to swap the file descriptor under its nose.
 	w.Close()
 	w, err = NewWatcher()
-	defer w.Close()
 	if err != nil {
 		t.Fatalf("Failed to create second watcher: %v", err)
 	}

--- a/integration_darwin_test.go
+++ b/integration_darwin_test.go
@@ -116,7 +116,6 @@ func testExchangedataForWatcher(t *testing.T, watchDir bool) {
 
 		// 2. Delete the intermediate file
 		err := os.Remove(intermediate)
-
 		if err != nil {
 			t.Fatalf("[%d] remove %s failed: %s", i, intermediate, err)
 		}
@@ -162,6 +161,6 @@ func createAndSyncFile(t *testing.T, filepath string) {
 	if err != nil {
 		t.Fatalf("creating %s failed: %s", filepath, err)
 	}
-	f1.Sync()
-	f1.Close()
+	ok(t, f1.Sync())
+	ok(t, f1.Close())
 }


### PR DESCRIPTION
#### What does this pull request do?

1. Simplifies `lint` CI job by removing `go vet` and `gofmt` (those are called by golangci-lint anyway).

2. Fixes all warnings found by the default set of golangci-lint checkers. In some cases those are real bugs, so please review carefully.

3. Stop ignoring golangci-lint warnings.

#### Where should the reviewer start?

Please review commit by commit, noting the commit messages.

⚠️ Currently the linters only check the code for the current platform (that is, Linux). There are multiple issues with *bsd and windows (those can be seen from CLI using e.g. `GOOS=darwin golangci-lint run`) that I am afraid to tackle.

#### How should this be manually tested?

No manual tests needed; this is why we have CI! 😉 👌🏻 