### PR TITLE
No error when stopping watching a non watched file

### DIFF
--- a/inotify.go
+++ b/inotify.go
@@ -134,7 +134,8 @@ func (w *Watcher) Remove(name string) error {
 
 	// Remove it from inotify.
 	if !ok {
-		return fmt.Errorf("can't remove non-existent inotify watch for: %s", name)
+		// Nothing to remove, as it's not present.
+		return nil
 	}
 
 	// We successfully removed the watch if InotifyRmWatch doesn't return an


### PR DESCRIPTION
#### What does this pull request do?
Currently, when a non-watched item is requested to be removed from a
watch, an error is returned.
However, the post-condition of removing it is: "This file/dir should not
be watched anymore", which is the case also when the item wasn't being
watched in the first place.
Rather than returning an error. Return nil and skip a part of the work.

#### Where should the reviewer start?
inotify.go, the Remove function definition.

#### How should this be manually tested?
We've noticed this because this lib is being used in promtail and it was logging errors because of this. 
