### PR TITLE
Add cmd/fsnotify

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ func main() {
 }
 ```
 
+A slightly more expansive example can be found in [cmd/fsnotify](cmd/fsnotify), which can be run with:
+
+        # Watch the current directory (not recursive).
+        $ go run ./cmd/fsnotify .
+
 ## Contributing
 
 Please refer to [CONTRIBUTING][] before opening an issue or pull request.

--- a/cmd/fsnotify/main.go
+++ b/cmd/fsnotify/main.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+func fatal(err error) {
+	if err == nil {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "%s: %s\n", filepath.Base(os.Args[0]), err)
+	os.Exit(1)
+}
+
+func line(s string, args ...interface{}) {
+	fmt.Printf(time.Now().Format("15:16:05.0000")+" "+s+"\n", args...)
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fatal(errors.New("must specify at least one path to watch"))
+	}
+
+	w, err := fsnotify.NewWatcher()
+	fatal(err)
+	defer w.Close()
+
+	go func() {
+		i := 0
+		for {
+			select {
+			case e, ok := <-w.Events:
+				if !ok {
+					return
+				}
+
+				i++
+				m := ""
+				if e.Op&fsnotify.Write == fsnotify.Write {
+					m = "(modified)"
+				}
+				line("%3d %-10s %-10s %q", i, e.Op, m, e.Name)
+			case err, ok := <-w.Errors:
+				if !ok {
+					return
+				}
+				line("ERROR: %s", err)
+			}
+		}
+	}()
+
+	for _, p := range os.Args[1:] {
+		err = w.Add(p)
+		if err != nil {
+			fatal(fmt.Errorf("%q: %w", p, err))
+		}
+	}
+
+	line("watching; press ^C to exit")
+	<-make(chan struct{})
+}


### PR DESCRIPTION
This adds a little example that can be run:

	% go run ./cmd/fsnotify **/*
	12:76:11.4710 watching; press ^C to exit
	12:76:13.6549   1 REMOVE                "cmd/fsnotify/4913"
	12:76:13.6550   2 RENAME                "cmd/fsnotify/main.go"
	12:76:13.6550   3 RENAME                "cmd/fsnotify/main.go"
	12:76:13.6612   4 CREATE                "cmd/fsnotify/main.go"
	12:76:13.6612   5 WRITE      (modified) "cmd/fsnotify/main.go"
	12:76:13.6614   6 WRITE      (modified) "cmd/fsnotify/main.go"
	12:76:13.6648   7 CHMOD                 "cmd/fsnotify/main.go"
	12:76:15.2919   8 CREATE                "cmd/fsnotify/4913"
	12:76:15.2919   9 REMOVE                "cmd/fsnotify/4913"
	12:76:15.2922  10 CHMOD                 "cmd/fsnotify/main.go"
	12:76:15.2923  11 REMOVE                "cmd/fsnotify/main.go"
	12:76:15.2925  12 RENAME                "cmd/fsnotify/main.go"
	12:76:15.2986  13 CREATE                "cmd/fsnotify/main.go"
	12:76:15.2986  14 WRITE      (modified) "cmd/fsnotify/main.go"
	12:76:15.2988  15 WRITE      (modified) "cmd/fsnotify/main.go"
	12:76:15.3024  16 CHMOD                 "cmd/fsnotify/main.go"
	^C

It's mostly the same as the example in the README, except that it takes
paths from the commandline and aligns things a bit nicer.

This is useful for documentation and experimentation. For example, while
reviewing some PRs I found it useful to quickly get an overview of "what
does fsnotify do now, and what does it do with this patch?"