### PR TITLE
Update link to CONTRIBUTING in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ fsnotify requires support from underlying OS to work. The current NFS protocol d
 [#11]: https://github.com/fsnotify/fsnotify/issues/11
 [#7]: https://github.com/howeyc/fsnotify/issues/7
 
-[contributing]: https://github.com/fsnotify/fsnotify/blob/master/CONTRIBUTING.md
+[contributing]: https://github.com/fsnotify/fsnotify/blob/main/CONTRIBUTING.md
 
 ## Related Projects
 


### PR DESCRIPTION
#### What does this pull request do?

Currently the README links to the CONTRIBUTING file on the `master` branch, while the default branch is now `main`.  
There have only been minor changes, but `main` is the current version.

