### PR TITLE
Test some more things in CI

### DIFF
--- a/.github/workflows/Vagrantfile.debian6
+++ b/.github/workflows/Vagrantfile.debian6
@@ -1,0 +1,6 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "threatstack/debian6"
+  config.vm.box_version = "1.0.0"
+
+  config.vm.define 'debian6'
+end 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,26 +7,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        goos:
-          - android
-          - darwin
-          - freebsd
-          - ios
-          - linux
-          - windows
-        goarch:
-          - amd64
-          - arm64
+        go:
+          - '1.16'
+          - '1.18'
     runs-on: ubuntu-latest
     steps:
       - name: setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: ${{ matrix.go }}
 
       - name: checkout
         uses: actions/checkout@v3
 
-      - name: build-${{ matrix.goos }}-${{ matrix.goarch }}
+      - name: build
         run: |
-          GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build
+          for a in $(go tool dist list); do
+            GOOS=${a%%/*} GOARCH=${a#*/} go build
+          done

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,30 @@
+name: test
+on:
+  push:
+  pull_request:
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '1.18'
+
+      - name: checkout
+        uses: actions/checkout@v3
+
+      - name: gofmt
+        run: |
+          test -z "$(gofmt -s -d . | tee /dev/stderr)"
+
+      - name: vet
+        run: |
+          go vet ./...
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        continue-on-error: true
+        with:
+          version: latest
+          skip-go-installation: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,12 +9,12 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-latest
+          - macos-11
+          - macos-12
           - windows-latest
         go:
-          - '1.18'
-          - '1.17'
           - '1.16'
+          - '1.18'
     runs-on: ${{ matrix.os }}
     steps:
       - name: setup Go
@@ -27,10 +27,10 @@ jobs:
 
       - name: test
         run: |
-          go test --race ./...
+          go test -race ./...
 
   testFreeBSD:
-    runs-on: macos-10.15
+    runs-on: macos-12
     name: test (freebsd, 1.18)
     steps:
       - uses: actions/checkout@v3
@@ -41,30 +41,41 @@ jobs:
           usesh: true
           prepare: pkg install -y go
           run: |
-            go test
+            go test -race ./...
 
-  lint:
-    runs-on: ubuntu-latest
+  testOpenBSD:
+    runs-on: macos-12
+    name: test (openbsd, 1.17)
     steps:
-      - name: setup Go
-        uses: actions/setup-go@v3
+      - uses: actions/checkout@v3
+      - name: test (openbsd, 1.17)
+        id: test
+        uses: vmactions/openbsd-vm@v0.0.6
         with:
-          go-version: '1.18'
+          prepare: pkg_add go
+          run: |
+            # Default of 512 leads to "too many open files".
+            ulimit -n 1024
 
-      - name: checkout
-        uses: actions/checkout@v3
+            # No -race as the VM doesn't include the comp set.
+            #
+            # TODO: should probably add this, but on my local machine the tests
+            #       time out with -race as the waits aren't long enough (OpenBSD
+            #       is kind of slow), so should probably look into that first.
+            #       Go 1.19 is supposed to have a much faster race detector, so
+            #       maybe waiting until we have that is enough.
+            go test ./...
 
-      - name: gofmt
-        run: |
-          test -z "$(gofmt -s -d . | tee /dev/stderr)"
-
-      - name: vet
-        run: |
-          go vet ./...
-
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
-        continue-on-error: true
+  testNetBSD:
+    runs-on: macos-12
+    name: test (netbsd, 1.17)
+    steps:
+      - uses: actions/checkout@v3
+      - name: test (netbsd, 1.17)
+        id: test
+        uses: vmactions/netbsd-vm@v0.0.4
         with:
-          version: latest
-          skip-go-installation: true
+          prepare: pkg_add go
+          run: |
+            # TODO: no -race for the same reason as OpenBSD (the timing; it does run).
+            go117 test ./...

--- a/.github/workflows/vagrant.yml
+++ b/.github/workflows/vagrant.yml
@@ -1,0 +1,26 @@
+name: vagrant
+on:
+  push:
+  pull_request:
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - debian6
+    runs-on: macos-12
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '1.18'
+
+      - name: test
+        run: |
+          cp -f .github/workflows/Vagrantfile.${{ matrix.image }} Vagrantfile
+          GOOS=linux GOARCH=amd64 go test -o fsnotify.test -c ./...
+          vagrant up
+          vagrant ssh -c "/vagrant/fsnotify.test"

--- a/README.md
+++ b/README.md
@@ -6,22 +6,26 @@
 
 `fsnotify` supports Windows, Linux, BSD and macOS with a common API.
 
-| Adapter               | OS                               | Status                                                                                                                          |
-| --------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| inotify               | Linux 2.6.27 or later, Android\* | Supported |
-| kqueue                | BSD, macOS, iOS\*                | Supported |
-| ReadDirectoryChangesW | Windows                          | Supported |
-| FSEvents              | macOS                            | [Planned](https://github.com/fsnotify/fsnotify/issues/11)                                                                       |
-| FEN                   | Solaris 11                       | [In Progress](https://github.com/fsnotify/fsnotify/pull/371)                                                                   |
-| fanotify              | Linux 2.6.37+                    | [Maybe](https://github.com/fsnotify/fsnotify/issues/114)                                                                      |
-| USN Journals          | Windows                          | [Maybe](https://github.com/fsnotify/fsnotify/issues/53)                                                                         |
-| Polling               | *All*                            | [Maybe](https://github.com/fsnotify/fsnotify/issues/9)                                                                          |
+| Adapter               | OS                       | Status                                                       |
+| --------------------- | -------------------------| -------------------------------------------------------------|
+| inotify               | Linux 2.6.32+, Android\* | Supported                                                    |
+| kqueue                | BSD, macOS, iOS\*        | Supported                                                    |
+| ReadDirectoryChangesW | Windows                  | Supported                                                    |
+| FSEvents              | macOS                    | [Planned](https://github.com/fsnotify/fsnotify/issues/11)    |
+| FEN                   | Solaris 11               | [In Progress](https://github.com/fsnotify/fsnotify/pull/371) |
+| fanotify              | Linux 2.6.37+            | [Maybe](https://github.com/fsnotify/fsnotify/issues/114)     |
+| USN Journals          | Windows                  | [Maybe](https://github.com/fsnotify/fsnotify/issues/53)      |
+| Polling               | *All*                    | [Maybe](https://github.com/fsnotify/fsnotify/issues/9)       |
 
 \* Android and iOS are untested.
 
-Please see [the documentation](https://pkg.go.dev/github.com/fsnotify/fsnotify) and consult the [FAQ](#faq) for usage information.
+fsnotify requires Go 1.16 or newer. Please see
+[the documentation](https://pkg.go.dev/github.com/fsnotify/fsnotify)
+and consult the [FAQ](#faq) for usage information.
 
-NOTE: fsnotify utilizes [`golang.org/x/sys`](https://pkg.go.dev/golang.org/x/sys) rather than [`syscall`](https://pkg.go.dev/syscall) from the standard library.
+NOTE: fsnotify utilizes
+[`golang.org/x/sys`](https://pkg.go.dev/golang.org/x/sys) rather than
+[`syscall`](https://pkg.go.dev/syscall) from the standard library.
 
 ## API stability
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -78,6 +78,10 @@ func addWatch(t *testing.T, watcher *Watcher, dir string) {
 }
 
 func TestFsnotifyMultipleOperations(t *testing.T) {
+	if runtime.GOOS == "netbsd" {
+		t.Skip("NetBSD behaviour is not fully correct") // TODO: investigate and fix.
+	}
+
 	watcher := newWatcher(t)
 
 	// Receive errors on the error channel on a separate goroutine

--- a/integration_test.go
+++ b/integration_test.go
@@ -14,6 +14,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -1255,6 +1256,10 @@ func TestCloseRace(t *testing.T) {
 	for i := 0; i < 150; i++ {
 		w, err := NewWatcher()
 		if err != nil {
+			if strings.Contains(err.Error(), "too many") { // syscall.EMFILE
+				time.Sleep(100 * time.Millisecond)
+				continue
+			}
 			t.Fatal(err)
 		}
 		go w.Close()


### PR DESCRIPTION
- Test all GOOS/GOARCH combinations by looping over "go tool dist list";
this just tests if it compiles.

- Add a Vagrant box to test Debian 6 / Linux 2.6.32; this was adapted
from @horahoradev's patch at https://github.com/fsnotify/fsnotify/pull/434.

- Update the minimum version requirements: we test Linux 2.6.32 now and
  turns out that's also the minimum version [Go supports] in recent
  releases, so just set it to that.

  Need Go 1.16 for retract in go.mod. I don't know, maybe we can just
  remove the retract? Latest Debian ships with Go 1.15.

  [Go supports]: https://github.com/golang/go/issues/45964

- Test both Go 1.16 and 1.18 (the lowest supported version and newest
  version). I guess we could also test 1.17, but the CI already takes
  somewhat long and I can't recall ever having a situation where an
  intermediate version failed.

- Test macOS 11 and 12; macOS 10.15 will (probably) end support in
  November, so probably not worth supporting this. GitHub will [remove]
  support for this at the end of August.

  [remove]: https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/

- Test OpenBSD, NetBSD. I had to skip a test to get it to work on NetBSD.

- Move "lint" to its own YAML file.

Future work:

- Actually run tests for all systems Go supports. Bit pointless right
  now as many of these don't do anything. Currently untested are
  Solaris, illumios, plan9, AIX, Android, iOS, DragonflyBSD, WASM.

  Some of these might be difficult (AIX, iOS, Android), but haven't
  looked in to it. I tried setting up Solaris with the
  vmactions/solaris, but it doesn't seem to have an easy way to install
  Go.

- GitHub only [supports] Windows Server 2019 and 2022; probabably also
  want to test Server 2016, but GitHub dropped support for this. Can
  maybe use AppVeyor(?)

  [supports]: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#choosing-github-hosted-runners

- Could maybe test older versions of BSD, too. Not sure of it's worth
  it.