### PR TITLE
Add {Event,Op}.Has()

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ func main() {
 					return
 				}
 				log.Println("event:", event)
-				if event.Op&fsnotify.Write == fsnotify.Write {
+				if event.Has(fsnotify.Write) {
 					log.Println("modified file:", event.Name)
 				}
 			case err, ok := <-watcher.Errors:

--- a/cmd/fsnotify/main.go
+++ b/cmd/fsnotify/main.go
@@ -42,7 +42,7 @@ func main() {
 
 				i++
 				m := ""
-				if e.Op&fsnotify.Write == fsnotify.Write {
+				if e.Has(fsnotify.Write) {
 					m = "(modified)"
 				}
 				line("%3d %-10s %-10s %q", i, e.Op, m, e.Name)


### PR DESCRIPTION
Using:

	if event.Op&fsnotify.Create == fsnotify.Create {
	}

is overly verbose and awkward; a Has() method makes this much nicer:

	if event.Has(fsnotify.Create) {
	}

PR #76 was previously rejected; I think that HasCreate() etc. is
overkill, but a Has() method makes the library quite a bit more
convenient IMO.

I added it to both the Event and Op to avoid confusion; with this we can
change the Op field to be private in a future v2.

Fixes #107