### PR TITLE
kqueue: don't set up watchers on unreadable files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,8 @@ jobs:
           usesh: true
           prepare: pkg install -y go
           run: |
-            go test -race ./...
+            pw user add -n action -m
+            su action -c 'go test -race ./...'
 
   testOpenBSD:
     runs-on: macos-12
@@ -54,18 +55,18 @@ jobs:
         uses: vmactions/openbsd-vm@v0.0.6
         with:
           prepare: pkg_add go
+          # No -race as the VM doesn't include the comp set.
+          #
+          # TODO: should probably add this, but on my local machine the tests
+          #       time out with -race as the waits aren't long enough (OpenBSD
+          #       is kind of slow), so should probably look into that first.
+          #       Go 1.19 is supposed to have a much faster race detector, so
+          #       maybe waiting until we have that is enough.
           run: |
             # Default of 512 leads to "too many open files".
             ulimit -n 1024
-
-            # No -race as the VM doesn't include the comp set.
-            #
-            # TODO: should probably add this, but on my local machine the tests
-            #       time out with -race as the waits aren't long enough (OpenBSD
-            #       is kind of slow), so should probably look into that first.
-            #       Go 1.19 is supposed to have a much faster race detector, so
-            #       maybe waiting until we have that is enough.
-            go test ./...
+            useradd -mG wheel action
+            su action -c 'go test ./...'
 
   testNetBSD:
     runs-on: macos-12
@@ -77,9 +78,10 @@ jobs:
         uses: vmactions/netbsd-vm@v0.0.4
         with:
           prepare: pkg_add go
+          # TODO: no -race for the same reason as OpenBSD (the timing; it does run).
           run: |
-            # TODO: no -race for the same reason as OpenBSD (the timing; it does run).
-            go117 test ./...
+            useradd -mG wheel action
+            su action -c 'go117 test ./...'
 
   testillumos:
     runs-on: macos-12

--- a/integration_test.go
+++ b/integration_test.go
@@ -4,6 +4,7 @@
 package fsnotify
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"runtime"
@@ -11,6 +12,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/fsnotify/fsnotify/internal"
 )
 
 func TestWatch(t *testing.T) {
@@ -78,6 +81,31 @@ func TestWatch(t *testing.T) {
 				write  /sub
 				remove /sub
 				remove /file
+		`},
+
+		{"file in directory is not readable", func(t *testing.T, w *Watcher, tmp string) {
+			if runtime.GOOS == "windows" {
+				t.Skip("attributes don't work on Windows")
+			}
+
+			touch(t, tmp, "file-unreadable")
+			chmod(t, 0, tmp, "file-unreadable")
+			touch(t, tmp, "file")
+			addWatch(t, w, tmp)
+
+			cat(t, "hello", tmp, "file")
+			rm(t, tmp, "file")
+			rm(t, tmp, "file-unreadable")
+		}, `
+			WRITE     "/file"
+			REMOVE    "/file"
+			REMOVE    "/file-unreadable"
+
+			# We never set up a watcher on the unreadable file, so we don't get
+			# the REMOVE.
+			kqueue:
+                WRITE    "/file"
+                REMOVE   "/file"
 		`},
 	}
 
@@ -441,6 +469,38 @@ func TestClose(t *testing.T) {
 			go w.Close()
 			go w.Close()
 			go w.Close()
+		}
+	})
+}
+
+func TestAdd(t *testing.T) {
+	t.Run("permission denied", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("attributes don't work on Windows")
+		}
+
+		t.Parallel()
+
+		tmp := t.TempDir()
+		dir := filepath.Join(tmp, "dir-unreadable")
+		mkdir(t, dir)
+		touch(t, dir, "/file")
+		chmod(t, 0, dir)
+
+		w := newWatcher(t)
+		defer func() {
+			w.Close()
+			chmod(t, 0o755, dir) // Make TempDir() cleanup work
+		}()
+		err := w.Add(dir)
+		if err == nil {
+			t.Fatal("error is nil")
+		}
+		if !errors.Is(err, internal.UnixEACCES) {
+			t.Errorf("not unix.EACCESS: %T %#[1]v", err)
+		}
+		if !errors.Is(err, internal.SyscallEACCES) {
+			t.Errorf("not syscall.EACCESS: %T %#[1]v", err)
 		}
 	})
 }

--- a/internal/unix.go
+++ b/internal/unix.go
@@ -1,0 +1,15 @@
+//go:build !windows
+// +build !windows
+
+package internal
+
+import (
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+var (
+	SyscallEACCES = syscall.EACCES
+	UnixEACCES    = unix.EACCES
+)

--- a/internal/windows.go
+++ b/internal/windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+// +build windows
+
+package internal
+
+import (
+	"errors"
+)
+
+// Just a dummy.
+var (
+	SyscallEACCES = errors.New("dummy")
+	UnixEACCES    = errors.New("dummy")
+)


### PR DESCRIPTION
Watching an entire directory would fail if it contains a file we can't
read due to permission errors. That's obviously not ideal, so just skip
the file.

Also add a test for trying to watch a directory where the permissions
are denied, and test the error is what's expected; this prevents
regressions like in #393.

Fixes #439