### PR TITLE
all: always use a pointer to sync.Mutex

### DIFF
--- a/helpers_test.go
+++ b/helpers_test.go
@@ -255,12 +255,12 @@ func chmod(t *testing.T, mode fs.FileMode, path ...string) {
 type eventCollector struct {
 	w      *Watcher
 	events Events
-	mu     sync.Mutex
+	mu     *sync.Mutex
 	done   chan struct{}
 }
 
 func newCollector(t *testing.T) *eventCollector {
-	return &eventCollector{w: newWatcher(t), done: make(chan struct{})}
+	return &eventCollector{w: newWatcher(t), mu: new(sync.Mutex), done: make(chan struct{})}
 }
 
 func (w *eventCollector) stop(t *testing.T) Events {

--- a/inotify.go
+++ b/inotify.go
@@ -27,7 +27,7 @@ type Watcher struct {
 	fd          int
 	Events      chan Event
 	Errors      chan error
-	mu          sync.Mutex // Map access
+	mu          *sync.Mutex // Map access
 	inotifyFile *os.File
 	watches     map[string]*watch // Map of inotify watches (key: path)
 	paths       map[int]string    // Map of watched paths (key: watch descriptor)
@@ -47,6 +47,7 @@ func NewWatcher() (*Watcher, error) {
 
 	w := &Watcher{
 		fd:          fd,
+		mu:          new(sync.Mutex),
 		inotifyFile: os.NewFile(uintptr(fd), ""),
 		watches:     make(map[string]*watch),
 		paths:       make(map[int]string),

--- a/integration_test.go
+++ b/integration_test.go
@@ -523,3 +523,15 @@ func TestRemove(t *testing.T) {
 		}
 	})
 }
+
+// Make sure we don't race if people pass the watcher by value.
+func TestWatcherByValue(t *testing.T) {
+	var (
+		tmp = t.TempDir()
+		w   = newWatcher(t)
+		ww  = *w
+	)
+	for i := 0; i < 10; i++ {
+		go ww.Add(tmp)
+	}
+}

--- a/kqueue.go
+++ b/kqueue.go
@@ -27,7 +27,7 @@ type Watcher struct {
 
 	kq int // File descriptor (as returned by the kqueue() syscall).
 
-	mu              sync.Mutex                  // Protects access to watcher data
+	mu              *sync.Mutex                 // Protects access to watcher data
 	watches         map[string]int              // Map of watched file descriptors (key: path).
 	watchesByDir    map[string]map[int]struct{} // Map of watched file descriptors indexed by the parent directory (key: dirname(path)).
 	externalWatches map[string]bool             // Map of watches added by user of the library.
@@ -51,6 +51,7 @@ func NewWatcher() (*Watcher, error) {
 
 	w := &Watcher{
 		kq:              kq,
+		mu:              new(sync.Mutex),
 		watches:         make(map[string]int),
 		watchesByDir:    make(map[string]map[int]struct{}),
 		dirFlags:        make(map[string]uint32),

--- a/windows.go
+++ b/windows.go
@@ -29,9 +29,9 @@ type Watcher struct {
 	input chan *input    // Inputs to the reader are sent on this channel
 	quit  chan chan<- error
 
-	mu       sync.Mutex // Protects access to watches, isClosed
-	watches  watchMap   // Map of watches (key: i-number)
-	isClosed bool       // Set to true when Close() is first called
+	mu       *sync.Mutex // Protects access to watches, isClosed
+	watches  watchMap    // Map of watches (key: i-number)
+	isClosed bool        // Set to true when Close() is first called
 }
 
 // NewWatcher establishes a new watcher with the underlying OS and begins waiting for events.
@@ -41,6 +41,7 @@ func NewWatcher() (*Watcher, error) {
 		return nil, os.NewSyscallError("CreateIoCompletionPort", e)
 	}
 	w := &Watcher{
+		mu:      new(sync.Mutex),
 		port:    port,
 		watches: make(watchMap),
 		input:   make(chan *input, 1),


### PR DESCRIPTION
You can't copy a mutex (well, you can, but then you create a new mutex
which loses the point of having one), so use a pointer, just in case
people pass the Watcher by value.

Note that "go vet" will warn about this:

	% go vet
	# github.com/fsnotify/fsnotify
	./integration_test.go:532:9: variable declaration copies lock value to ww: github.com/fsnotify/fsnotify.Watcher contains sync.Mutex

But there's no real downside to using a pointer here.

Fixes #164