### PR TITLE
ci: update to use Go 1.19, kick off fewer builds, update x/sys

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,14 @@
 name: 'build'
-on:   ['push', 'pull_request']
+on:
+  push:
+    paths: ['**.go', 'go.mod', '.github/workflows/*']
+
 jobs:
   cross-compile:
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.16', '1.18']
+        go: ['1.16', '1.19']
     runs-on: ubuntu-latest
     steps:
       - name: setup Go
@@ -18,6 +21,7 @@ jobs:
 
       - name: build
         run: |
+          set -x
           for a in $(go tool dist list); do
             GOOS=${a%%/*} GOARCH=${a#*/} go build
           done

--- a/.github/workflows/staticcheck.yml
+++ b/.github/workflows/staticcheck.yml
@@ -1,5 +1,8 @@
 name: 'staticcheck'
-on:   ['push', 'pull_request']
+on:
+  push:
+    paths: ['**.go', 'go.mod', '.github/workflows/*']
+
 jobs:
   staticcheck:
     name:    'staticcheck'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: 'test'
-on:   ['push', 'pull_request']
+on:
+  push:
+    paths: ['**.go', 'go.mod', '.github/workflows/*']
+
 jobs:
   test:
     strategy:
@@ -12,7 +15,7 @@ jobs:
           - windows-latest
         go:
           - '1.16'
-          - '1.18'
+          - '1.19'
     runs-on: ${{ matrix.os }}
     steps:
       - name: setup Go

--- a/.github/workflows/vagrant.yml
+++ b/.github/workflows/vagrant.yml
@@ -1,7 +1,10 @@
-name: 'test'
-on:   ['push', 'pull_request']
+name: 'test-vagrant'
+on:
+  push:
+    paths: ['**.go', 'go.mod', '.github/workflows/*']
+
 jobs:
-  test:
+  test-vagrant:
     strategy:
       fail-fast: false
       matrix:
@@ -23,7 +26,7 @@ jobs:
       - name: setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: '1.19'
 
       - name: test
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
-# Setup a Global .gitignore for OS and editor generated files:
-# https://help.github.com/articles/ignoring-files
-# git config --global core.excludesfile ~/.gitignore_global
+# go test -c output
+*.test
 
-.vagrant
-*.sublime-project
+# Output of go build ./cmd/fsnotify
+/fsnotify

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,9 @@ module github.com/fsnotify/fsnotify
 
 go 1.16
 
-require golang.org/x/sys v0.0.0-20220412211240-33da011f77ad
+require golang.org/x/sys v0.0.0-20220731174439-a90be440212d
 
 retract (
-    v1.5.3 // Published an incorrect branch accidentally https://github.com/fsnotify/fsnotify/issues/445
-    v1.5.0 // Contains symlink regression https://github.com/fsnotify/fsnotify/pull/394
+	v1.5.3 // Published an incorrect branch accidentally https://github.com/fsnotify/fsnotify/issues/445
+	v1.5.0 // Contains symlink regression https://github.com/fsnotify/fsnotify/pull/394
 )

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.0.0-20220412211240-33da011f77ad h1:ntjMns5wyP/fN65tdBD4g8J5w8n015+iIIs9rtjXkY0=
-golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220731174439-a90be440212d h1:Sv5ogFZatcgIMMtBSTTAgMYsicp25MXBubjXNDKwm80=
+golang.org/x/sys v0.0.0-20220731174439-a90be440212d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
We need to update x/sys to support GOARCH=loong64, which is new in Go
1.19.

Also kick off fewer builds; they regularly get hung in the queue as we
have quite a few test jobs now.