### PR TITLE
windows: increase buffer size from 4K to 64K

### DIFF
--- a/windows.go
+++ b/windows.go
@@ -195,7 +195,7 @@ type watch struct {
 	mask   uint64            // Directory itself is being watched with these notify flags
 	names  map[string]uint64 // Map of names being watched and their notify flags
 	rename string            // Remembers the old name while renaming a file
-	buf    [4096]byte
+	buf    [65536]byte       // 64K buffer
 }
 
 type (


### PR DESCRIPTION
People are running in to trouble because the 4K buffer can overflow;
see: #72.

This is not a "real" fix, but I think a 64K buffer is acceptable even on
memory-limited machines; no one is running the Windows on an Arduino,
and even with something like 128M of memory, the extra 124K is basically
negligible. There is also no real performance difference between
allocating a large array vs. a small array: they're both comparable.

It should probably be enough for most applications. Need to look in the
future to either dynamically grow the size, or allow setting it similar
to what tilt does as mentioned in #72.