### PR TITLE
Use "os.Rename()" in tests instead of "mv"

### DIFF
--- a/helpers_test.go
+++ b/helpers_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"sort"
@@ -184,13 +183,7 @@ func mv(t *testing.T, src string, dst ...string) {
 		t.Fatalf("mv: dst must have at least one element: %s", dst)
 	}
 
-	var err error
-	switch runtime.GOOS {
-	case "windows", "plan9":
-		err = os.Rename(src, filepath.Join(dst...))
-	default:
-		err = exec.Command("mv", src, filepath.Join(dst...)).Run()
-	}
+	err := os.Rename(src, filepath.Join(dst...))
 	if err != nil {
 		t.Fatalf("mv(%q, %q): %s", src, filepath.Join(dst...), err)
 	}
@@ -440,4 +433,9 @@ func cmpEvents(t *testing.T, tmp string, have, want Events) {
 
 func indent(s fmt.Stringer) string {
 	return "\t" + strings.ReplaceAll(s.String(), "\n", "\n\t")
+}
+
+func isCI() bool {
+	_, ok := os.LookupEnv("CI")
+	return ok
 }

--- a/integration_test.go
+++ b/integration_test.go
@@ -113,8 +113,8 @@ func TestWatchRename(t *testing.T) {
 		`},
 
 		{"rename to unwatched directory", func(t *testing.T, w *Watcher, tmp string) {
-			if runtime.GOOS == "netbsd" {
-				t.Skip("NetBSD behaviour is not fully correct") // TODO: investigate and fix.
+			if runtime.GOOS == "netbsd" && isCI() {
+				t.Skip("fails in CI; see #488")
 			}
 
 			unwatched := t.TempDir()
@@ -128,10 +128,10 @@ func TestWatchRename(t *testing.T) {
 			cat(t, "data", renamed) // Modify the file outside of the watched dir
 			touch(t, file)          // Recreate the file that was moved
 		}, `
-			create /file
-			write  /file
-			rename /file
-			create /file
+			create /file # cat data >file
+			write  /file # ^
+			rename /file # mv file ../renamed
+			create /file # touch file
 
 			# Windows has REMOVE /file, rather than CREATE /file
 			windows:


### PR DESCRIPTION
This was added in 00f2dfd (2011): "BSD Test: Need to use outside program
to trigger some events". All tests pass fine with just os.Rename(), so
just use that.

Might add another real-world test in the future for common tools like
mv, cp, vi, etc. because they don't always behave the same as library
calls, but calling mv in *only* the mv() helper is rather odd.

This also renames a few things in the kqueue backend for clarity, and
uses map[string]struct{} if we just use them for lookups to an
allocation (I originally tried to fix #488, but gave up on that for now,
hence the kqueue changes).