### PR TITLE
windows: run TestWatchRename/rename_overwriting_existing_file

### DIFF
--- a/inotify.go
+++ b/inotify.go
@@ -241,11 +241,12 @@ func (w *Watcher) readEvents() {
 		// We don't know how many events we just read into the buffer
 		// While the offset points to at least one whole event...
 		for offset <= uint32(n-unix.SizeofInotifyEvent) {
-			// Point "raw" to the event in the buffer
-			raw := (*unix.InotifyEvent)(unsafe.Pointer(&buf[offset]))
-
-			mask := uint32(raw.Mask)
-			nameLen := uint32(raw.Len)
+			var (
+				// Point "raw" to the event in the buffer
+				raw     = (*unix.InotifyEvent)(unsafe.Pointer(&buf[offset]))
+				mask    = uint32(raw.Mask)
+				nameLen = uint32(raw.Len)
+			)
 
 			if mask&unix.IN_Q_OVERFLOW != 0 {
 				select {

--- a/integration_test.go
+++ b/integration_test.go
@@ -142,11 +142,6 @@ func TestWatchRename(t *testing.T) {
 		`},
 
 		{"rename overwriting existing file", func(t *testing.T, w *Watcher, tmp string) {
-			switch runtime.GOOS {
-			case "windows":
-				t.Skipf("os.Rename over existing file does not create an event on %q", runtime.GOOS)
-			}
-
 			touch(t, tmp, "renamed")
 			addWatch(t, w, tmp)
 
@@ -158,10 +153,8 @@ func TestWatchRename(t *testing.T) {
 			remove /renamed
 			create /renamed
 
-			# No remove event for Windows and Linux.
+			# No remove event for inotify; inotify just sends MOVE_SELF.
 			linux:
-				create /renamed
-			windows:
 				create /renamed
 		`},
 


### PR DESCRIPTION
This Skip() was added in 2013 (c825c6d) with "Windows cannot overwrite
file on rename", but it seems to work fine. os.Rename() is also
documented as "If newpath already exists and is not a directory, Rename
replaces it", so if it *doesn't* work it's a bug in os.Rename(). Maybe
os.Rename() behaved different nine years ago.