### PR TITLE
windows: test symlinks

### DIFF
--- a/helpers_test.go
+++ b/helpers_test.go
@@ -348,12 +348,15 @@ func (e Events) copy() Events {
 //   # Windows-specific test.
 //   windows:
 //     WRITE    path
+//
+// You can specify multiple platforms with a comma (e.g. "windows, linux:").
+// "kqueue" is a shortcut for all kqueue systems (BSD, macOS).
 func newEvents(t *testing.T, s string) Events {
 	t.Helper()
 
 	var (
 		lines  = strings.Split(s, "\n")
-		group  string
+		groups = []string{""}
 		events = make(map[string]Events)
 	)
 	for no, line := range lines {
@@ -365,7 +368,10 @@ func newEvents(t *testing.T, s string) Events {
 			continue
 		}
 		if strings.HasSuffix(line, ":") {
-			group = strings.TrimRight(line, ":")
+			groups = strings.Split(strings.TrimRight(line, ":"), ",")
+			for i := range groups {
+				groups[i] = strings.TrimSpace(groups[i])
+			}
 			continue
 		}
 
@@ -398,7 +404,10 @@ func newEvents(t *testing.T, s string) Events {
 				}
 			}
 		}
-		events[group] = append(events[group], Event{Name: path, Op: op})
+
+		for _, g := range groups {
+			events[g] = append(events[g], Event{Name: path, Op: op})
+		}
 	}
 
 	if e, ok := events[runtime.GOOS]; ok {

--- a/integration_test.go
+++ b/integration_test.go
@@ -196,10 +196,6 @@ func TestWatchRename(t *testing.T) {
 }
 
 func TestWatchSymlink(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("symlinks don't work on Windows")
-	}
-
 	tests := []testCase{
 		{"create unresolvable symlink", func(t *testing.T, w *Watcher, tmp string) {
 			addWatch(t, w, tmp)
@@ -207,6 +203,10 @@ func TestWatchSymlink(t *testing.T) {
 			symlink(t, filepath.Join(tmp, "target"), tmp, "link")
 		}, `
 			create /link
+
+			windows:
+                create    /link
+                write     /link
 		`},
 
 		{"cyclic symlink", func(t *testing.T, w *Watcher, tmp string) {
@@ -234,7 +234,7 @@ func TestWatchSymlink(t *testing.T) {
 			write  /link
 			create /link
 
-			linux:
+			linux, windows:
 				remove    /link
 				create    /link
 				write     /link


### PR DESCRIPTION
Symlinks are supported since Windows Vista; there's no reason to not
test it.