### PR TITLE
update the basic example on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ func main() {
 					return
 				}
 				log.Println("event:", event)
-				if event.Has(fsnotify.Write) {
+				if event.Op == fsnotify.Write {
 					log.Println("modified file:", event.Name)
 				}
 			case err, ok := <-watcher.Errors:


### PR DESCRIPTION
`fsnotify.Event` does not have the `Has` method. I'm not sure what `Has` was supposed to do, but I'm guessing that it might be equivalent to using the `==` for the Op of event