### PR TITLE
Return ErrClosed on Add() when the watcher is closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Additions
 
-- Add FEN backend to support illumos and Solaris. ([#371])
+- illumos: add FEN backend to support illumos and Solaris. ([#371])
+
+### Changes and fixes
+
+- all: return ErrClosed on Add() when the watcher is closed ([#516])
 
 [#371]: https://github.com/fsnotify/fsnotify/pull/371
+[#516]: https://github.com/fsnotify/fsnotify/pull/516
 
 ## [1.6.0] - 2022-10-13
 

--- a/backend_fen.go
+++ b/backend_fen.go
@@ -196,6 +196,8 @@ func (w *Watcher) Close() error {
 // Notifications on network filesystems (NFS, SMB, FUSE, etc.) or special
 // filesystems (/proc, /sys, etc.) generally don't work.
 //
+// Returns [ErrClosed] if [Watcher.Close] was called.
+//
 // # Watching directories
 //
 // All files in a directory are monitored, including new files that are created
@@ -215,7 +217,7 @@ func (w *Watcher) Close() error {
 // you're not interested in. There is an example of this in [cmd/fsnotify/file.go].
 func (w *Watcher) Add(name string) error {
 	if w.isClosed() {
-		return errors.New("FEN watcher already closed")
+		return ErrClosed
 	}
 	if w.port.PathIsWatched(name) {
 		return nil
@@ -260,7 +262,7 @@ func (w *Watcher) Add(name string) error {
 // Removing a path that has not yet been added returns [ErrNonExistentWatch].
 func (w *Watcher) Remove(name string) error {
 	if w.isClosed() {
-		return errors.New("FEN watcher already closed")
+		return nil
 	}
 	if !w.port.PathIsWatched(name) {
 		return fmt.Errorf("%w: %s", ErrNonExistentWatch, name)
@@ -528,7 +530,7 @@ func (w *Watcher) updateDirectory(path string) error {
 
 func (w *Watcher) associateFile(path string, stat os.FileInfo, follow bool) error {
 	if w.isClosed() {
-		return errors.New("FEN watcher already closed")
+		return ErrClosed
 	}
 	// This is primarily protecting the call to AssociatePath
 	// but it is important and intentional that the call to
@@ -552,10 +554,10 @@ func (w *Watcher) associateFile(path string, stat os.FileInfo, follow bool) erro
 		}
 	}
 	// FILE_NOFOLLOW means we watch symlinks themselves rather than their targets
-	events := unix.FILE_MODIFIED|unix.FILE_ATTRIB|unix.FILE_NOFOLLOW
+	events := unix.FILE_MODIFIED | unix.FILE_ATTRIB | unix.FILE_NOFOLLOW
 	if follow {
 		// We *DO* follow symlinks for explicitly watched entries
-		events = unix.FILE_MODIFIED|unix.FILE_ATTRIB
+		events = unix.FILE_MODIFIED | unix.FILE_ATTRIB
 	}
 	return w.port.AssociatePath(path, stat,
 		events,
@@ -570,7 +572,13 @@ func (w *Watcher) dissociateFile(path string, stat os.FileInfo, unused bool) err
 }
 
 // WatchList returns all paths added with [Add] (and are not yet removed).
+//
+// Returns nil if [Watcher.Close] was called.
 func (w *Watcher) WatchList() []string {
+	if w.isClosed() {
+		return nil
+	}
+
 	w.mu.Lock()
 	defer w.mu.Unlock()
 

--- a/backend_other.go
+++ b/backend_other.go
@@ -34,6 +34,8 @@ func (w *Watcher) Close() error {
 // Notifications on network filesystems (NFS, SMB, FUSE, etc.) or special
 // filesystems (/proc, /sys, etc.) generally don't work.
 //
+// Returns [ErrClosed] if [Watcher.Close] was called.
+//
 // # Watching directories
 //
 // All files in a directory are monitored, including new files that are created

--- a/fsnotify.go
+++ b/fsnotify.go
@@ -42,8 +42,9 @@ const (
 
 // Common errors that can be reported by a watcher
 var (
-	ErrNonExistentWatch = errors.New("can't remove non-existent watcher")
-	ErrEventOverflow    = errors.New("fsnotify queue overflow")
+	ErrNonExistentWatch = errors.New("fsnotify: can't remove non-existent watcher")
+	ErrEventOverflow    = errors.New("fsnotify: queue overflow")
+	ErrClosed           = errors.New("fsnotify: watcher already closed")
 )
 
 func (op Op) String() string {

--- a/fsnotify_test.go
+++ b/fsnotify_test.go
@@ -892,6 +892,28 @@ func TestClose(t *testing.T) {
 
 		chanClosed(t, w.w)
 	})
+
+	t.Run("error after closed", func(t *testing.T) {
+		t.Parallel()
+
+		tmp := t.TempDir()
+		w := newWatcher(t, tmp)
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		file := filepath.Join(tmp, "file")
+		touch(t, file)
+		if err := w.Add(file); !errors.Is(err, ErrClosed) {
+			t.Fatalf("wrong error for Add: %#v", err)
+		}
+		if err := w.Remove(file); err != nil {
+			t.Fatalf("wrong error for Remove: %#v", err)
+		}
+		if l := w.WatchList(); l != nil { // Should return an error, but meh :-/
+			t.Fatalf("WatchList not nil: %#v", l)
+		}
+	})
 }
 
 func TestAdd(t *testing.T) {

--- a/mkdoc.zsh
+++ b/mkdoc.zsh
@@ -87,6 +87,8 @@ add=$(<<EOF
 // Notifications on network filesystems (NFS, SMB, FUSE, etc.) or special
 // filesystems (/proc, /sys, etc.) generally don't work.
 //
+// Returns [ErrClosed] if [Watcher.Close] was called.
+//
 // # Watching directories
 //
 // All files in a directory are monitored, including new files that are created
@@ -124,6 +126,8 @@ EOF
 
 watchlist=$(<<EOF
 // WatchList returns all paths added with [Add] (and are not yet removed).
+//
+// Returns nil if [Watcher.Close] was called.
 EOF
 )
 


### PR DESCRIPTION
Also consistently return nil for Remove() and WatchList(). For Remove() we could return an error, but I don't really see the point: if the watcher is closed it's basically a no-op so returning nil is fine.

For WatchList() I'd like to return an error, but there is no error return, so explicitly returning nil is the best we can do.

Fixes #511