### PR TITLE
Check privileges for symlink tests on Windows

### DIFF
--- a/fsnotify_test.go
+++ b/fsnotify_test.go
@@ -166,6 +166,9 @@ func TestWatch(t *testing.T) {
 				// behaviour too.
 				t.Skip("broken on macOS")
 			}
+			if !hasPrivilegesForSymlink() {
+				t.Skip("does not have privileges for symlink on this OS")
+			}
 
 			file := join(tmp, "file")
 			link := join(tmp, "link")
@@ -194,6 +197,9 @@ func TestWatch(t *testing.T) {
 				// Pretty sure this is caused by the broken symlink-follow
 				// behaviour too.
 				t.Skip("broken on macOS")
+			}
+			if !hasPrivilegesForSymlink() {
+				t.Skip("does not have privileges for symlink on this OS")
 			}
 
 			dir := join(tmp, "dir")
@@ -246,6 +252,9 @@ func TestWatchCreate(t *testing.T) {
 
 		// Links
 		{"create new symlink to file", func(t *testing.T, w *Watcher, tmp string) {
+			if !hasPrivilegesForSymlink() {
+				t.Skip("does not have privileges for symlink on this OS")
+			}
 			touch(t, tmp, "file")
 			addWatch(t, w, tmp)
 			symlink(t, join(tmp, "file"), tmp, "link")
@@ -253,6 +262,9 @@ func TestWatchCreate(t *testing.T) {
 			create  /link
 		`},
 		{"create new symlink to directory", func(t *testing.T, w *Watcher, tmp string) {
+			if !hasPrivilegesForSymlink() {
+				t.Skip("does not have privileges for symlink on this OS")
+			}
 			addWatch(t, w, tmp)
 			symlink(t, tmp, tmp, "link")
 		}, `
@@ -505,6 +517,10 @@ func TestWatchRename(t *testing.T) {
 }
 
 func TestWatchSymlink(t *testing.T) {
+	if !hasPrivilegesForSymlink() {
+		t.Skip("does not have privileges for symlink on this OS")
+	}
+
 	tests := []testCase{
 		{"create unresolvable symlink", func(t *testing.T, w *Watcher, tmp string) {
 			addWatch(t, w, tmp)

--- a/fsnotify_test.go
+++ b/fsnotify_test.go
@@ -166,7 +166,7 @@ func TestWatch(t *testing.T) {
 				// behaviour too.
 				t.Skip("broken on macOS")
 			}
-			if !hasPrivilegesForSymlink() {
+			if !internal.HasPrivilegesForSymlink() {
 				t.Skip("does not have privileges for symlink on this OS")
 			}
 
@@ -198,7 +198,7 @@ func TestWatch(t *testing.T) {
 				// behaviour too.
 				t.Skip("broken on macOS")
 			}
-			if !hasPrivilegesForSymlink() {
+			if !internal.HasPrivilegesForSymlink() {
 				t.Skip("does not have privileges for symlink on this OS")
 			}
 
@@ -252,7 +252,7 @@ func TestWatchCreate(t *testing.T) {
 
 		// Links
 		{"create new symlink to file", func(t *testing.T, w *Watcher, tmp string) {
-			if !hasPrivilegesForSymlink() {
+			if !internal.HasPrivilegesForSymlink() {
 				t.Skip("does not have privileges for symlink on this OS")
 			}
 			touch(t, tmp, "file")
@@ -262,7 +262,7 @@ func TestWatchCreate(t *testing.T) {
 			create  /link
 		`},
 		{"create new symlink to directory", func(t *testing.T, w *Watcher, tmp string) {
-			if !hasPrivilegesForSymlink() {
+			if !internal.HasPrivilegesForSymlink() {
 				t.Skip("does not have privileges for symlink on this OS")
 			}
 			addWatch(t, w, tmp)
@@ -517,7 +517,7 @@ func TestWatchRename(t *testing.T) {
 }
 
 func TestWatchSymlink(t *testing.T) {
-	if !hasPrivilegesForSymlink() {
+	if !internal.HasPrivilegesForSymlink() {
 		t.Skip("does not have privileges for symlink on this OS")
 	}
 
@@ -768,7 +768,8 @@ func TestWatchRm(t *testing.T) {
 }
 
 // TODO: this fails reguarly in the CI; not sure if it's a bug with the test or
-//       code; need to look in to it.
+//
+//	code; need to look in to it.
 func TestClose(t *testing.T) {
 	chanClosed := func(t *testing.T, w *Watcher) {
 		t.Helper()
@@ -988,7 +989,8 @@ func TestAdd(t *testing.T) {
 }
 
 // TODO: should also check internal state is correct/cleaned up; e.g. no
-//       left-over file descriptors or whatnot.
+//
+//	left-over file descriptors or whatnot.
 func TestRemove(t *testing.T) {
 	t.Run("works", func(t *testing.T) {
 		t.Parallel()

--- a/fsnotify_test.go
+++ b/fsnotify_test.go
@@ -768,8 +768,7 @@ func TestWatchRm(t *testing.T) {
 }
 
 // TODO: this fails reguarly in the CI; not sure if it's a bug with the test or
-//
-//	code; need to look in to it.
+//       code; need to look in to it.
 func TestClose(t *testing.T) {
 	chanClosed := func(t *testing.T, w *Watcher) {
 		t.Helper()
@@ -989,8 +988,7 @@ func TestAdd(t *testing.T) {
 }
 
 // TODO: should also check internal state is correct/cleaned up; e.g. no
-//
-//	left-over file descriptors or whatnot.
+//       left-over file descriptors or whatnot.
 func TestRemove(t *testing.T) {
 	t.Run("works", func(t *testing.T) {
 		t.Parallel()

--- a/internal/unix.go
+++ b/internal/unix.go
@@ -30,3 +30,7 @@ func SetRlimit() {
 func Maxfiles() uint64                              { return maxfiles }
 func Mkfifo(path string, mode uint32) error         { return unix.Mkfifo(path, mode) }
 func Mknod(path string, mode uint32, dev int) error { return unix.Mknod(path, mode, dev) }
+
+func HasPrivilegesForSymlink() bool {
+	return true
+}

--- a/internal/unix.go
+++ b/internal/unix.go
@@ -30,7 +30,3 @@ func SetRlimit() {
 func Maxfiles() uint64                              { return maxfiles }
 func Mkfifo(path string, mode uint32) error         { return unix.Mkfifo(path, mode) }
 func Mknod(path string, mode uint32, dev int) error { return unix.Mknod(path, mode, dev) }
-
-func HasPrivilegesForSymlink() bool {
-	return true
-}

--- a/internal/unix2.go
+++ b/internal/unix2.go
@@ -1,0 +1,8 @@
+//go:build !windows
+// +build !windows
+
+package internal
+
+func HasPrivilegesForSymlink() bool {
+	return true
+}

--- a/internal/windows.go
+++ b/internal/windows.go
@@ -5,6 +5,8 @@ package internal
 
 import (
 	"errors"
+
+	"golang.org/x/sys/windows"
 )
 
 // Just a dummy.
@@ -17,3 +19,24 @@ func SetRlimit()                                    {}
 func Maxfiles() uint64                              { return 1<<64 - 1 }
 func Mkfifo(path string, mode uint32) error         { return errors.New("no FIFOs on Windows") }
 func Mknod(path string, mode uint32, dev int) error { return errors.New("no device nodes on Windows") }
+
+func HasPrivilegesForSymlink() bool {
+	var sid *windows.SID
+	err := windows.AllocateAndInitializeSid(
+		&windows.SECURITY_NT_AUTHORITY,
+		2,
+		windows.SECURITY_BUILTIN_DOMAIN_RID,
+		windows.DOMAIN_ALIAS_RID_ADMINS,
+		0, 0, 0, 0, 0, 0,
+		&sid)
+	if err != nil {
+		return false
+	}
+	defer windows.FreeSid(sid)
+	token := windows.Token(0)
+	member, err := token.IsMember(sid)
+	if err != nil {
+		return false
+	}
+	return member || token.IsElevated()
+}


### PR DESCRIPTION
Tests for symlink always fail when run the tests as non-admin users on Windows since Windows require privileges to create symlinks. This CL change to check the privileges.

(Can I put label `hacktoberfest-accepted` on this PR ?)