### PR TITLE
kqueue: fix removing a directory

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,12 @@
+freebsd_task:
+  name: 'FreeBSD'
+  freebsd_instance:
+    image_family: freebsd-13-1
+  install_script:
+    - pkg update -f
+    - pkg install -y go
+  test_script:
+      # run tests as user "cirrus" instead of root
+    - pw useradd cirrus -m
+    - chown -R cirrus:cirrus .
+    - sudo -u cirrus go test -race ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,22 +72,6 @@ jobs:
         run: |
           go test -race ./...
 
-  # FreeBSD
-  testFreeBSD:
-    runs-on: macos-12
-    name: test (freebsd, 1.18)
-    steps:
-      - uses: actions/checkout@v3
-      - name: test (freebsd, 1.18)
-        id: test
-        uses: vmactions/freebsd-vm@v0
-        with:
-          usesh: true
-          prepare: pkg install -y go
-          run: |
-            pw user add -n action -m
-            su action -c 'go test -race ./...'
-
   # OpenBSD; no -race as the VM doesn't include the comp set.
   #
   # TODO: should probably add this, but on my local machine the tests time out

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: test (freebsd, 1.18)
         id: test
-        uses: vmactions/freebsd-vm@v0.2.0
+        uses: vmactions/freebsd-vm@v0
         with:
           usesh: true
           prepare: pkg install -y go
@@ -102,7 +102,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: test (openbsd, 1.17)
         id: test
-        uses: vmactions/openbsd-vm@v0.0.6
+        uses: vmactions/openbsd-vm@v0
         with:
           prepare: pkg_add go
           run: |
@@ -117,7 +117,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: test (netbsd, 1.18)
         id: test
-        uses: vmactions/netbsd-vm@v0.0.4
+        uses: vmactions/netbsd-vm@v0
         with:
           prepare: pkg_add go
           # TODO: no -race for the same reason as OpenBSD (the timing; it does run).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ Unreleased
 
 - all: return `ErrClosed` on `Add()` when the watcher is closed ([#516])
 
-- kqueue: deal with `rm -rf watched-dir` better ([#526])
+- kqueue: deal with `rm -rf watched-dir` better ([#526], [#537])
 
 - Add `Watcher.Errors` and `Watcher.Events` to the no-op `Watcher` in
   `backend_other.go`, making it easier to use on unsupported platforms such as
@@ -53,6 +53,7 @@ Unreleased
 [#525]: https://github.com/fsnotify/fsnotify/pull/525
 [#526]: https://github.com/fsnotify/fsnotify/pull/526
 [#528]: https://github.com/fsnotify/fsnotify/pull/528
+[#537]: https://github.com/fsnotify/fsnotify/pull/537
 
 1.6.0 - 2022-10-13
 -------------------


### PR DESCRIPTION
Fix regression from #526, which would sometimes fail with something along the lines of:

    --- FAIL: TestWatchRm/remove_watched_directory (1.30s)
        helpers_test.go:384: fsnotify.sendDirectoryChangeEvents: open /tmp/TestWatchRmremove_watched_directory2055111636/001: no such file or directory
        fsnotify_test.go:750:
            have:
            	REMOVE               "/a"
            	REMOVE               "/b"
            	REMOVE               "/c"
            	REMOVE               "/d"
            	REMOVE               "/e"
            	REMOVE               "/f"
            	REMOVE               "/g"
            want:
            	REMOVE               "/"
            	REMOVE               "/a"
            	REMOVE               "/b"
            	REMOVE               "/c"
            	REMOVE               "/d"
            	REMOVE               "/e"
            	REMOVE               "/f"
            	REMOVE               "/g"
            	REMOVE               "/h"
            	REMOVE               "/i"
            	REMOVE               "/j"

We can just always ignore a directory no longer existing; kqueue should still send the correct events.