### PR TITLE
A few staticcheck fixes

### DIFF
--- a/.github/workflows/staticcheck.yml
+++ b/.github/workflows/staticcheck.yml
@@ -10,9 +10,28 @@ jobs:
     name:    'staticcheck'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 1
-    - uses: dominikh/staticcheck-action@v1.2.0
-      with:
-        version: '2022.1'
+      - id: install_go
+        uses: WillAbides/setup-go-faster@v1.7.0
+        with:
+          go-version: "1.19.x"
+
+      - uses: actions/cache@v3
+        with:
+          key: ${{ runner.os }}-staticcheck
+          path: |
+            ${{ runner.temp }}/staticcheck
+            ${{ steps.install_go.outputs.GOCACHE || '' }}
+
+      - run: |
+          export STATICCHECK_CACHE="${{ runner.temp }}/staticcheck"
+          go install honnef.co/go/tools/cmd/staticcheck@latest
+
+          $(go env GOPATH)/bin/staticcheck -matrix <<EOF
+          windows: GOOS=windows
+          linux: GOOS=linux
+          freebsd: GOOS=freebsd
+          openbsd: GOOS=openbsd
+          netbsd: GOOS=netbsd
+          darwin: GOOS=darwin
+          illumos: GOOS=illumos
+          EOF

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,9 +40,13 @@ Unreleased
 
 - kqueue: deal with `rm -rf watched-dir` better ([#526], [#537])
 
-- Add `Watcher.Errors` and `Watcher.Events` to the no-op `Watcher` in
+- other: add `Watcher.Errors` and `Watcher.Events` to the no-op `Watcher` in
   `backend_other.go`, making it easier to use on unsupported platforms such as
   WASM, AIX, etc. ([#528])
+
+- other: use the backend_other.go no-op if the `appengine` build tag is set;
+  Google AppEngine forbids usage of the unsafe package so the inotify backend
+  won't work there.
 
 
 [#371]: https://github.com/fsnotify/fsnotify/pull/371

--- a/backend_windows.go
+++ b/backend_windows.go
@@ -635,6 +635,8 @@ func (w *Watcher) readEvents() {
 		}
 
 		switch qErr {
+		case nil:
+			// No error
 		case windows.ERROR_MORE_DATA:
 			if watch == nil {
 				w.sendError(errors.New("ERROR_MORE_DATA has unexpectedly null lpOverlapped buffer"))
@@ -656,7 +658,6 @@ func (w *Watcher) readEvents() {
 		default:
 			w.sendError(os.NewSyscallError("GetQueuedCompletionPort", qErr))
 			continue
-		case nil:
 		}
 
 		var offset uint32
@@ -733,8 +734,9 @@ func (w *Watcher) readEvents() {
 
 			// Error!
 			if offset >= n {
+				//lint:ignore ST1005 Windows should be capitalized
 				w.sendError(errors.New(
-					"Windows system assumed buffer larger than it is, events have likely been missed."))
+					"Windows system assumed buffer larger than it is, events have likely been missed"))
 				break
 			}
 		}

--- a/internal/freebsd.go
+++ b/internal/freebsd.go
@@ -16,8 +16,8 @@ var (
 
 var maxfiles uint64
 
-// Go 1.19 will do this automatically: https://go-review.googlesource.com/c/go/+/393354/
 func SetRlimit() {
+	// Go 1.19 will do this automatically: https://go-review.googlesource.com/c/go/+/393354/
 	var l syscall.Rlimit
 	err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &l)
 	if err == nil && l.Cur != l.Max {

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -1,0 +1,2 @@
+// Package internal contains some helpers.
+package internal

--- a/internal/unix.go
+++ b/internal/unix.go
@@ -16,8 +16,8 @@ var (
 
 var maxfiles uint64
 
-// Go 1.19 will do this automatically: https://go-review.googlesource.com/c/go/+/393354/
 func SetRlimit() {
+	// Go 1.19 will do this automatically: https://go-review.googlesource.com/c/go/+/393354/
 	var l syscall.Rlimit
 	err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &l)
 	if err == nil && l.Cur != l.Max {


### PR DESCRIPTION
This fixes a few small staticcheck issues; turns out that staticcheck only compiles the files for the current GOOS:
https://staticcheck.io/docs/running-staticcheck/cli/build-tags/

You can run all systems with:

	staticcheck -matrix <<EOF
	windows: GOOS=windows
	linux: GOOS=linux
	freebsd: GOOS=freebsd
	openbsd: GOOS=openbsd
	netbsd: GOOS=netbsd
	darwin: GOOS=darwin
	illumos: GOOS=illumos
	EOF

The CI runner doesn't really support that, but it's little more than a small wrapper around "go install" with some variables, so just use that directly instead of the action.