### PR TITLE
Add recursive watcher for Windows backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Unreleased
 - all: add `AddWith()`, which is identical to `Add()` but allows passing
   options. ([#521])
 
+- all: support recursively watching paths with `Add("path/...")`. ([#540])
+
 - windows: allow setting the buffer size with `fsnotify.WithBufferSize()`; the
   default of 64K is the highest value that works on all platforms and is enough
   for most purposes, but in some cases a highest buffer is needed. ([#521])
@@ -46,7 +48,7 @@ Unreleased
 
 - other: use the backend_other.go no-op if the `appengine` build tag is set;
   Google AppEngine forbids usage of the unsafe package so the inotify backend
-  won't work there.
+  won't compile there.
 
 
 [#371]: https://github.com/fsnotify/fsnotify/pull/371
@@ -58,6 +60,7 @@ Unreleased
 [#526]: https://github.com/fsnotify/fsnotify/pull/526
 [#528]: https://github.com/fsnotify/fsnotify/pull/528
 [#537]: https://github.com/fsnotify/fsnotify/pull/537
+[#540]: https://github.com/fsnotify/fsnotify/pull/540
 
 1.6.0 - 2022-10-13
 -------------------

--- a/backend_fen.go
+++ b/backend_fen.go
@@ -66,6 +66,16 @@ import (
 // The sysctl variables kern.maxfiles and kern.maxfilesperproc can be used to
 // control the maximum number of open files, as well as /etc/login.conf on BSD
 // systems.
+//
+// # Windows notes
+//
+// Paths can be added as "C:\path\to\dir", but forward slashes
+// ("C:/path/to/dir") will also work.
+//
+// The default buffer size is 64K, which is the largest value that is guaranteed
+// to work with SMB filesystems. If you have many events in quick succession
+// this may not be enough, and you will have to use [WithBufferSize] to increase
+// the value.
 type Watcher struct {
 	// Events sends the filesystem change events.
 	//

--- a/backend_fen.go
+++ b/backend_fen.go
@@ -1,6 +1,9 @@
 //go:build solaris
 // +build solaris
 
+// Note: the documentation on the Watcher type and methods is generated from
+// mkdoc.zsh
+
 package fsnotify
 
 import (

--- a/backend_fen.go
+++ b/backend_fen.go
@@ -270,8 +270,8 @@ func (w *Watcher) AddWith(name string, opts ...addOpt) error {
 // Remove stops monitoring the path for changes.
 //
 // If the path was added as a recursive watch (e.g. as "/tmp/dir/...") then the
-// entire recusrice watch will be removed. You can use both "/tmp/dir" and
-// "/tmp/dir/..." (they behave identical).
+// entire recursive watch will be removed. You can use either "/tmp/dir" or
+// "/tmp/dir/..." (they behave identically).
 //
 // You cannot remove individual files or subdirectories from recursive watches;
 // e.g. Add("/tmp/path/...") and then Remove("/tmp/path/sub") will fail.

--- a/backend_fen.go
+++ b/backend_fen.go
@@ -92,6 +92,8 @@ type Watcher struct {
 	//                      you may get hundreds of Write events, so you
 	//                      probably want to wait until you've stopped receiving
 	//                      them (see the dedup example in cmd/fsnotify).
+	//                      Some systems may send Write event for directories
+	//                      when the directory content changes.
 	//
 	//   fsnotify.Chmod     Attributes were changed. On Linux this is also sent
 	//                      when a file is removed (or more accurately, when a
@@ -184,7 +186,7 @@ func (w *Watcher) Close() error {
 //
 // A path can only be watched once; attempting to watch it more than once will
 // return an error. Paths that do not yet exist on the filesystem cannot be
-// added.
+// watched.
 //
 // A watch will be automatically removed if the watched path is deleted or
 // renamed. The exception is the Windows backend, which doesn't remove the
@@ -200,8 +202,9 @@ func (w *Watcher) Close() error {
 // # Watching directories
 //
 // All files in a directory are monitored, including new files that are created
-// after the watcher is started. Subdirectories are not watched (i.e. it's
-// non-recursive).
+// after the watcher is started. By default subdirectories are not watched (i.e.
+// it's non-recursive), but if the path ends with "/..." all files and
+// subdirectories are watched too.
 //
 // # Watching files
 //
@@ -266,8 +269,15 @@ func (w *Watcher) AddWith(name string, opts ...addOpt) error {
 
 // Remove stops monitoring the path for changes.
 //
-// Directories are always removed non-recursively. For example, if you added
-// /tmp/dir and /tmp/dir/subdir then you will need to remove both.
+// If the path was added as a recursive watch (e.g. as "/tmp/dir/...") then the
+// entire recusrice watch will be removed. You can use both "/tmp/dir" and
+// "/tmp/dir/..." (they behave identical).
+//
+// You cannot remove individual files or subdirectories from recursive watches;
+// e.g. Add("/tmp/path/...") and then Remove("/tmp/path/sub") will fail.
+//
+// For other watches directories are removed non-recursively. For example, if
+// you added "/tmp/dir" and "/tmp/dir/subdir" then you will need to remove both.
 //
 // Removing a path that has not yet been added returns [ErrNonExistentWatch].
 //

--- a/backend_inotify.go
+++ b/backend_inotify.go
@@ -285,8 +285,8 @@ func (w *Watcher) AddWith(name string, opts ...addOpt) error {
 // Remove stops monitoring the path for changes.
 //
 // If the path was added as a recursive watch (e.g. as "/tmp/dir/...") then the
-// entire recusrice watch will be removed. You can use both "/tmp/dir" and
-// "/tmp/dir/..." (they behave identical).
+// entire recursive watch will be removed. You can use either "/tmp/dir" or
+// "/tmp/dir/..." (they behave identically).
 //
 // You cannot remove individual files or subdirectories from recursive watches;
 // e.g. Add("/tmp/path/...") and then Remove("/tmp/path/sub") will fail.

--- a/backend_inotify.go
+++ b/backend_inotify.go
@@ -95,6 +95,8 @@ type Watcher struct {
 	//                      you may get hundreds of Write events, so you
 	//                      probably want to wait until you've stopped receiving
 	//                      them (see the dedup example in cmd/fsnotify).
+	//                      Some systems may send Write event for directories
+	//                      when the directory content changes.
 	//
 	//   fsnotify.Chmod     Attributes were changed. On Linux this is also sent
 	//                      when a file is removed (or more accurately, when a
@@ -206,7 +208,7 @@ func (w *Watcher) Close() error {
 //
 // A path can only be watched once; attempting to watch it more than once will
 // return an error. Paths that do not yet exist on the filesystem cannot be
-// added.
+// watched.
 //
 // A watch will be automatically removed if the watched path is deleted or
 // renamed. The exception is the Windows backend, which doesn't remove the
@@ -222,8 +224,9 @@ func (w *Watcher) Close() error {
 // # Watching directories
 //
 // All files in a directory are monitored, including new files that are created
-// after the watcher is started. Subdirectories are not watched (i.e. it's
-// non-recursive).
+// after the watcher is started. By default subdirectories are not watched (i.e.
+// it's non-recursive), but if the path ends with "/..." all files and
+// subdirectories are watched too.
 //
 // # Watching files
 //
@@ -281,8 +284,15 @@ func (w *Watcher) AddWith(name string, opts ...addOpt) error {
 
 // Remove stops monitoring the path for changes.
 //
-// Directories are always removed non-recursively. For example, if you added
-// /tmp/dir and /tmp/dir/subdir then you will need to remove both.
+// If the path was added as a recursive watch (e.g. as "/tmp/dir/...") then the
+// entire recusrice watch will be removed. You can use both "/tmp/dir" and
+// "/tmp/dir/..." (they behave identical).
+//
+// You cannot remove individual files or subdirectories from recursive watches;
+// e.g. Add("/tmp/path/...") and then Remove("/tmp/path/sub") will fail.
+//
+// For other watches directories are removed non-recursively. For example, if
+// you added "/tmp/dir" and "/tmp/dir/subdir" then you will need to remove both.
 //
 // Removing a path that has not yet been added returns [ErrNonExistentWatch].
 //

--- a/backend_inotify.go
+++ b/backend_inotify.go
@@ -1,6 +1,9 @@
 //go:build linux && !appengine
 // +build linux,!appengine
 
+// Note: the documentation on the Watcher type and methods is generated from
+// mkdoc.zsh
+
 package fsnotify
 
 import (

--- a/backend_inotify.go
+++ b/backend_inotify.go
@@ -69,6 +69,16 @@ import (
 // The sysctl variables kern.maxfiles and kern.maxfilesperproc can be used to
 // control the maximum number of open files, as well as /etc/login.conf on BSD
 // systems.
+//
+// # Windows notes
+//
+// Paths can be added as "C:\path\to\dir", but forward slashes
+// ("C:/path/to/dir") will also work.
+//
+// The default buffer size is 64K, which is the largest value that is guaranteed
+// to work with SMB filesystems. If you have many events in quick succession
+// this may not be enough, and you will have to use [WithBufferSize] to increase
+// the value.
 type Watcher struct {
 	// Events sends the filesystem change events.
 	//

--- a/backend_inotify_test.go
+++ b/backend_inotify_test.go
@@ -93,6 +93,7 @@ func TestInotifyDeleteOpenFile(t *testing.T) {
 	w.collect(t)
 
 	rm(t, file)
+	eventSeparator()
 	e := w.events(t)
 	cmpEvents(t, tmp, e, newEvents(t, `chmod /file`))
 

--- a/backend_kqueue.go
+++ b/backend_kqueue.go
@@ -66,6 +66,16 @@ import (
 // The sysctl variables kern.maxfiles and kern.maxfilesperproc can be used to
 // control the maximum number of open files, as well as /etc/login.conf on BSD
 // systems.
+//
+// # Windows notes
+//
+// Paths can be added as "C:\path\to\dir", but forward slashes
+// ("C:/path/to/dir") will also work.
+//
+// The default buffer size is 64K, which is the largest value that is guaranteed
+// to work with SMB filesystems. If you have many events in quick succession
+// this may not be enough, and you will have to use [WithBufferSize] to increase
+// the value.
 type Watcher struct {
 	// Events sends the filesystem change events.
 	//

--- a/backend_kqueue.go
+++ b/backend_kqueue.go
@@ -1,6 +1,9 @@
 //go:build freebsd || openbsd || netbsd || dragonfly || darwin
 // +build freebsd openbsd netbsd dragonfly darwin
 
+// Note: the documentation on the Watcher type and methods is generated from
+// mkdoc.zsh
+
 package fsnotify
 
 import (

--- a/backend_kqueue.go
+++ b/backend_kqueue.go
@@ -92,6 +92,8 @@ type Watcher struct {
 	//                      you may get hundreds of Write events, so you
 	//                      probably want to wait until you've stopped receiving
 	//                      them (see the dedup example in cmd/fsnotify).
+	//                      Some systems may send Write event for directories
+	//                      when the directory content changes.
 	//
 	//   fsnotify.Chmod     Attributes were changed. On Linux this is also sent
 	//                      when a file is removed (or more accurately, when a
@@ -237,7 +239,7 @@ func (w *Watcher) Close() error {
 //
 // A path can only be watched once; attempting to watch it more than once will
 // return an error. Paths that do not yet exist on the filesystem cannot be
-// added.
+// watched.
 //
 // A watch will be automatically removed if the watched path is deleted or
 // renamed. The exception is the Windows backend, which doesn't remove the
@@ -253,8 +255,9 @@ func (w *Watcher) Close() error {
 // # Watching directories
 //
 // All files in a directory are monitored, including new files that are created
-// after the watcher is started. Subdirectories are not watched (i.e. it's
-// non-recursive).
+// after the watcher is started. By default subdirectories are not watched (i.e.
+// it's non-recursive), but if the path ends with "/..." all files and
+// subdirectories are watched too.
 //
 // # Watching files
 //
@@ -288,8 +291,15 @@ func (w *Watcher) AddWith(name string, opts ...addOpt) error {
 
 // Remove stops monitoring the path for changes.
 //
-// Directories are always removed non-recursively. For example, if you added
-// /tmp/dir and /tmp/dir/subdir then you will need to remove both.
+// If the path was added as a recursive watch (e.g. as "/tmp/dir/...") then the
+// entire recusrice watch will be removed. You can use both "/tmp/dir" and
+// "/tmp/dir/..." (they behave identical).
+//
+// You cannot remove individual files or subdirectories from recursive watches;
+// e.g. Add("/tmp/path/...") and then Remove("/tmp/path/sub") will fail.
+//
+// For other watches directories are removed non-recursively. For example, if
+// you added "/tmp/dir" and "/tmp/dir/subdir" then you will need to remove both.
 //
 // Removing a path that has not yet been added returns [ErrNonExistentWatch].
 //

--- a/backend_kqueue.go
+++ b/backend_kqueue.go
@@ -292,8 +292,8 @@ func (w *Watcher) AddWith(name string, opts ...addOpt) error {
 // Remove stops monitoring the path for changes.
 //
 // If the path was added as a recursive watch (e.g. as "/tmp/dir/...") then the
-// entire recusrice watch will be removed. You can use both "/tmp/dir" and
-// "/tmp/dir/..." (they behave identical).
+// entire recursive watch will be removed. You can use either "/tmp/dir" or
+// "/tmp/dir/..." (they behave identically).
 //
 // You cannot remove individual files or subdirectories from recursive watches;
 // e.g. Add("/tmp/path/...") and then Remove("/tmp/path/sub") will fail.

--- a/backend_other.go
+++ b/backend_other.go
@@ -58,6 +58,16 @@ import "errors"
 // The sysctl variables kern.maxfiles and kern.maxfilesperproc can be used to
 // control the maximum number of open files, as well as /etc/login.conf on BSD
 // systems.
+//
+// # Windows notes
+//
+// Paths can be added as "C:\path\to\dir", but forward slashes
+// ("C:/path/to/dir") will also work.
+//
+// The default buffer size is 64K, which is the largest value that is guaranteed
+// to work with SMB filesystems. If you have many events in quick succession
+// this may not be enough, and you will have to use [WithBufferSize] to increase
+// the value.
 type Watcher struct {
 	// Events sends the filesystem change events.
 	//

--- a/backend_other.go
+++ b/backend_other.go
@@ -1,6 +1,9 @@
 //go:build appengine || (!darwin && !dragonfly && !freebsd && !openbsd && !linux && !netbsd && !solaris && !windows)
 // +build appengine !darwin,!dragonfly,!freebsd,!openbsd,!linux,!netbsd,!solaris,!windows
 
+// Note: the documentation on the Watcher type and methods is generated from
+// mkdoc.zsh
+
 package fsnotify
 
 import "errors"

--- a/backend_other.go
+++ b/backend_other.go
@@ -84,6 +84,8 @@ type Watcher struct {
 	//                      you may get hundreds of Write events, so you
 	//                      probably want to wait until you've stopped receiving
 	//                      them (see the dedup example in cmd/fsnotify).
+	//                      Some systems may send Write event for directories
+	//                      when the directory content changes.
 	//
 	//   fsnotify.Chmod     Attributes were changed. On Linux this is also sent
 	//                      when a file is removed (or more accurately, when a
@@ -119,7 +121,7 @@ func (w *Watcher) WatchList() []string { return nil }
 //
 // A path can only be watched once; attempting to watch it more than once will
 // return an error. Paths that do not yet exist on the filesystem cannot be
-// added.
+// watched.
 //
 // A watch will be automatically removed if the watched path is deleted or
 // renamed. The exception is the Windows backend, which doesn't remove the
@@ -135,8 +137,9 @@ func (w *Watcher) WatchList() []string { return nil }
 // # Watching directories
 //
 // All files in a directory are monitored, including new files that are created
-// after the watcher is started. Subdirectories are not watched (i.e. it's
-// non-recursive).
+// after the watcher is started. By default subdirectories are not watched (i.e.
+// it's non-recursive), but if the path ends with "/..." all files and
+// subdirectories are watched too.
 //
 // # Watching files
 //
@@ -162,8 +165,15 @@ func (w *Watcher) AddWith(name string, opts ...addOpt) error { return nil }
 
 // Remove stops monitoring the path for changes.
 //
-// Directories are always removed non-recursively. For example, if you added
-// /tmp/dir and /tmp/dir/subdir then you will need to remove both.
+// If the path was added as a recursive watch (e.g. as "/tmp/dir/...") then the
+// entire recusrice watch will be removed. You can use both "/tmp/dir" and
+// "/tmp/dir/..." (they behave identical).
+//
+// You cannot remove individual files or subdirectories from recursive watches;
+// e.g. Add("/tmp/path/...") and then Remove("/tmp/path/sub") will fail.
+//
+// For other watches directories are removed non-recursively. For example, if
+// you added "/tmp/dir" and "/tmp/dir/subdir" then you will need to remove both.
 //
 // Removing a path that has not yet been added returns [ErrNonExistentWatch].
 //

--- a/backend_other.go
+++ b/backend_other.go
@@ -166,8 +166,8 @@ func (w *Watcher) AddWith(name string, opts ...addOpt) error { return nil }
 // Remove stops monitoring the path for changes.
 //
 // If the path was added as a recursive watch (e.g. as "/tmp/dir/...") then the
-// entire recusrice watch will be removed. You can use both "/tmp/dir" and
-// "/tmp/dir/..." (they behave identical).
+// entire recursive watch will be removed. You can use either "/tmp/dir" or
+// "/tmp/dir/..." (they behave identically).
 //
 // You cannot remove individual files or subdirectories from recursive watches;
 // e.g. Add("/tmp/path/...") and then Remove("/tmp/path/sub") will fail.

--- a/backend_windows.go
+++ b/backend_windows.go
@@ -266,8 +266,8 @@ func (w *Watcher) AddWith(name string, opts ...addOpt) error {
 // Remove stops monitoring the path for changes.
 //
 // If the path was added as a recursive watch (e.g. as "/tmp/dir/...") then the
-// entire recusrice watch will be removed. You can use both "/tmp/dir" and
-// "/tmp/dir/..." (they behave identical).
+// entire recursive watch will be removed. You can use either "/tmp/dir" or
+// "/tmp/dir/..." (they behave identically).
 //
 // You cannot remove individual files or subdirectories from recursive watches;
 // e.g. Add("/tmp/path/...") and then Remove("/tmp/path/sub") will fail.

--- a/backend_windows.go
+++ b/backend_windows.go
@@ -74,6 +74,16 @@ import (
 // The sysctl variables kern.maxfiles and kern.maxfilesperproc can be used to
 // control the maximum number of open files, as well as /etc/login.conf on BSD
 // systems.
+//
+// # Windows notes
+//
+// Paths can be added as "C:\path\to\dir", but forward slashes
+// ("C:/path/to/dir") will also work.
+//
+// The default buffer size is 64K, which is the largest value that is guaranteed
+// to work with SMB filesystems. If you have many events in quick succession
+// this may not be enough, and you will have to use [WithBufferSize] to increase
+// the value.
 type Watcher struct {
 	// Events sends the filesystem change events.
 	//
@@ -530,7 +540,7 @@ func (w *Watcher) remWatch(pathname string) error {
 	w.mu.Unlock()
 
 	if recurse && !watch.recurse {
-		return fmt.Errorf("can't use /... with non-recursive watch %q", pathname)
+		return fmt.Errorf("can't use \\... with non-recursive watch %q", pathname)
 	}
 
 	err = windows.CloseHandle(ino.handle)

--- a/backend_windows.go
+++ b/backend_windows.go
@@ -4,6 +4,9 @@
 // Windows backend based on ReadDirectoryChangesW()
 //
 // https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-readdirectorychangesw
+//
+// Note: the documentation on the Watcher type and methods is generated from
+// mkdoc.zsh
 
 package fsnotify
 

--- a/fsnotify.go
+++ b/fsnotify.go
@@ -133,8 +133,8 @@ func WithBufferSize(bytes int) addOpt {
 	return func(opt *withOpts) { opt.bufsize = bytes }
 }
 
-// Check if this path is recursive (ends with "/..."), and return the path with
-// the /... stripped.
+// Check if this path is recursive (ends with "/..." or "\..."), and return the
+// path with the /... stripped.
 func recursivePath(path string) (string, bool) {
 	if filepath.Base(path) == "..." {
 		return filepath.Dir(path), true

--- a/fsnotify.go
+++ b/fsnotify.go
@@ -12,6 +12,7 @@ package fsnotify
 import (
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strings"
 )
 
@@ -130,4 +131,13 @@ func getOptions(opts ...addOpt) withOpts {
 // you're hitting "queue or buffer overflow" errors ([ErrEventOverflow]).
 func WithBufferSize(bytes int) addOpt {
 	return func(opt *withOpts) { opt.bufsize = bytes }
+}
+
+// Check if this path is recursive (ends with "/..."), and return the path with
+// the /... stripped.
+func recursivePath(path string) (string, bool) {
+	if filepath.Base(path) == "..." {
+		return filepath.Dir(path), true
+	}
+	return path, false
 }

--- a/fsnotify_test.go
+++ b/fsnotify_test.go
@@ -656,7 +656,7 @@ func TestWatchAttrib(t *testing.T) {
 	}
 }
 
-func TestWatchRm(t *testing.T) {
+func TestWatchRemove(t *testing.T) {
 	tests := []testCase{
 		{"remove watched file", func(t *testing.T, w *Watcher, tmp string) {
 			file := join(tmp, "file")
@@ -758,6 +758,194 @@ func TestWatchRm(t *testing.T) {
 				WRITE                "/i"
 				WRITE                "/j"
 				WRITE                "/j"
+		`},
+
+		{"remove recursive", func(t *testing.T, w *Watcher, tmp string) {
+			recurseOnly(t)
+
+			mkdirAll(t, tmp, "dir1", "subdir")
+			mkdirAll(t, tmp, "dir2", "subdir")
+			touch(t, tmp, "dir1", "subdir", "file")
+			touch(t, tmp, "dir2", "subdir", "file")
+
+			addWatch(t, w, tmp, "dir1", "...")
+			addWatch(t, w, tmp, "dir2", "...")
+			cat(t, "asd", tmp, "dir1", "subdir", "file")
+			cat(t, "asd", tmp, "dir2", "subdir", "file")
+
+			if err := w.Remove(join(tmp, "dir1")); err != nil {
+				t.Fatal(err)
+			}
+			if err := w.Remove(join(tmp, "dir2", "...")); err != nil {
+				t.Fatal(err)
+			}
+
+			if w := w.WatchList(); len(w) != 0 {
+				t.Errorf("WatchList not empty: %s", w)
+			}
+
+			cat(t, "asd", tmp, "dir1", "subdir", "file")
+			cat(t, "asd", tmp, "dir2", "subdir", "file")
+		}, `
+			write /dir1/subdir
+			write /dir1/subdir/file
+			write /dir2/subdir
+			write /dir2/subdir/file
+		`},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		tt.run(t)
+	}
+}
+
+func TestWatchRecursive(t *testing.T) {
+	recurseOnly(t)
+
+	tests := []testCase{
+		// Make a nested directory tree, then write some files there.
+		{"basic", func(t *testing.T, w *Watcher, tmp string) {
+			mkdirAll(t, tmp, "/one/two/three/four")
+			addWatch(t, w, tmp, "/...")
+
+			cat(t, "asd", tmp, "/file.txt")
+			cat(t, "asd", tmp, "/one/two/three/file.txt")
+		}, `
+			create    /file.txt                  # cat asd >file.txt
+			write     /file.txt
+
+			write     /one/two/three             # cat asd >one/two/three/file.txt
+			create    /one/two/three/file.txt
+			write     /one/two/three/file.txt
+		`},
+
+		// Create a new directory tree and then some files under that.
+		{"add directory", func(t *testing.T, w *Watcher, tmp string) {
+			mkdirAll(t, tmp, "/one/two/three/four")
+			addWatch(t, w, tmp, "/...")
+
+			mkdirAll(t, tmp, "/one/two/new/dir")
+			touch(t, tmp, "/one/two/new/file")
+			touch(t, tmp, "/one/two/new/dir/file")
+		}, `
+			write     /one/two                # mkdir -p one/two/new/dir
+			create    /one/two/new
+			create    /one/two/new/dir
+
+			write     /one/two/new            # touch one/two/new/file
+			create    /one/two/new/file
+
+			create    /one/two/new/dir/file   # touch one/two/new/dir/file
+		`},
+
+		// Remove nested directory
+		{"remove directory", func(t *testing.T, w *Watcher, tmp string) {
+			mkdirAll(t, tmp, "one/two/three/four")
+			addWatch(t, w, tmp, "...")
+
+			cat(t, "asd", tmp, "one/two/three/file.txt")
+			rmAll(t, tmp, "one/two")
+		}, `
+			write                /one/two/three            # cat asd >one/two/three/file.txt
+			create               /one/two/three/file.txt
+			write                /one/two/three/file.txt
+
+			write                /one/two                  # rm -r one/two
+			write                /one/two/three
+			remove               /one/two/three/file.txt
+			remove               /one/two/three/four
+			write                /one/two/three
+			remove               /one/two/three
+			write                /one/two
+			remove               /one/two
+		`},
+
+		// Rename nested directory
+		{"rename directory", func(t *testing.T, w *Watcher, tmp string) {
+			mkdirAll(t, tmp, "/one/two/three/four")
+			addWatch(t, w, tmp, "...")
+
+			mv(t, filepath.Join(tmp, "one"), tmp, "one-rename")
+			touch(t, tmp, "one-rename/file")
+			touch(t, tmp, "one-rename/two/three/file")
+		}, `
+			rename               "/one"                        # mv one one-rename
+			create               "/one-rename"
+
+			write                "/one-rename"                 # touch one-rename/file
+			create               "/one-rename/file"
+
+			write                "/one-rename/two/three"       # touch one-rename/two/three/file
+			create               "/one-rename/two/three/file"
+		`},
+
+		{"remove watched directory", func(t *testing.T, w *Watcher, tmp string) {
+			mk := func(r string) {
+				touch(t, r, "a")
+				touch(t, r, "b")
+				touch(t, r, "c")
+				touch(t, r, "d")
+				touch(t, r, "e")
+				touch(t, r, "f")
+				touch(t, r, "g")
+
+				mkdir(t, r, "h")
+				mkdir(t, r, "h", "a")
+				mkdir(t, r, "i")
+				mkdir(t, r, "i", "a")
+				mkdir(t, r, "j")
+				mkdir(t, r, "j", "a")
+			}
+			mk(tmp)
+			mkdir(t, tmp, "sub")
+			mk(join(tmp, "sub"))
+
+			addWatch(t, w, tmp, "...")
+			rmAll(t, tmp)
+		}, `
+			remove               "/a"
+			remove               "/b"
+			remove               "/c"
+			remove               "/d"
+			remove               "/e"
+			remove               "/f"
+			remove               "/g"
+			write                "/h"
+			remove               "/h/a"
+			write                "/h"
+			remove               "/h"
+			write                "/i"
+			remove               "/i/a"
+			write                "/i"
+			remove               "/i"
+			write                "/j"
+			remove               "/j/a"
+			write                "/j"
+			remove               "/j"
+			write                "/sub"
+			remove               "/sub/a"
+			remove               "/sub/b"
+			remove               "/sub/c"
+			remove               "/sub/d"
+			remove               "/sub/e"
+			remove               "/sub/f"
+			remove               "/sub/g"
+			write                "/sub/h"
+			remove               "/sub/h/a"
+			write                "/sub/h"
+			remove               "/sub/h"
+			write                "/sub/i"
+			remove               "/sub/i/a"
+			write                "/sub/i"
+			remove               "/sub/i"
+			write                "/sub/j"
+			remove               "/sub/j/a"
+			write                "/sub/j"
+			remove               "/sub/j"
+			write                "/sub"
+			remove               "/sub"
+			remove               "/"
 		`},
 	}
 
@@ -1063,6 +1251,23 @@ func TestRemove(t *testing.T) {
 			w.Close()
 		}
 	})
+
+	t.Run("remove with ... when non-recursive", func(t *testing.T) {
+		recurseOnly(t)
+		t.Parallel()
+
+		tmp := t.TempDir()
+		w := newWatcher(t)
+		addWatch(t, w, tmp)
+
+		if err := w.Remove(join(tmp, "...")); err == nil {
+			t.Fatal("err was nil")
+		}
+		if err := w.Remove(tmp); err != nil {
+			t.Fatal(err)
+		}
+	})
+
 }
 
 func TestEventString(t *testing.T) {

--- a/fsnotify_test.go
+++ b/fsnotify_test.go
@@ -866,7 +866,7 @@ func TestWatchRecursive(t *testing.T) {
 			mkdirAll(t, tmp, "/one/two/three/four")
 			addWatch(t, w, tmp, "...")
 
-			mv(t, filepath.Join(tmp, "one"), tmp, "one-rename")
+			mv(t, join(tmp, "one"), tmp, "one-rename")
 			touch(t, tmp, "one-rename/file")
 			touch(t, tmp, "one-rename/two/three/file")
 		}, `

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -138,19 +138,19 @@ func mkdir(t *testing.T, path ...string) {
 }
 
 // mkdir -p
-// func mkdirAll(t *testing.T, path ...string) {
-// 	t.Helper()
-// 	if len(path) < 1 {
-// 		t.Fatalf("mkdirAll: path must have at least one element: %s", path)
-// 	}
-// 	err := os.MkdirAll(join(path...), 0o0755)
-// 	if err != nil {
-// 		t.Fatalf("mkdirAll(%q): %s", join(path...), err)
-// 	}
-// 	if shouldWait(path...) {
-// 		eventSeparator()
-// 	}
-// }
+func mkdirAll(t *testing.T, path ...string) {
+	t.Helper()
+	if len(path) < 1 {
+		t.Fatalf("mkdirAll: path must have at least one element: %s", path)
+	}
+	err := os.MkdirAll(join(path...), 0o0755)
+	if err != nil {
+		t.Fatalf("mkdirAll(%q): %s", join(path...), err)
+	}
+	if shouldWait(path...) {
+		eventSeparator()
+	}
+}
 
 // ln -s
 func symlink(t *testing.T, target string, link ...string) {
@@ -575,4 +575,13 @@ func isSolaris() bool {
 		return true
 	}
 	return false
+}
+
+func recurseOnly(t *testing.T) {
+	switch runtime.GOOS {
+	case "windows":
+		// Run test.
+	default:
+		t.Skip("recursion not yet supported on " + runtime.GOOS)
+	}
 }

--- a/mkdoc.zsh
+++ b/mkdoc.zsh
@@ -2,8 +2,8 @@
 [ "${ZSH_VERSION:-}" = "" ] && echo >&2 "Only works with zsh" && exit 1
 setopt err_exit no_unset pipefail extended_glob
 
-# Simple script to update the godoc comments on all watchers. Probably took me
-# more time to write this than doing it manually, but ah well 🙃
+# Simple script to update the godoc comments on all watchers so you don't need
+# to update the same comment 5 times.
 
 watcher=$(<<EOF
 // Watcher watches a set of paths, delivering events on a channel.

--- a/mkdoc.zsh
+++ b/mkdoc.zsh
@@ -56,6 +56,16 @@ watcher=$(<<EOF
 // The sysctl variables kern.maxfiles and kern.maxfilesperproc can be used to
 // control the maximum number of open files, as well as /etc/login.conf on BSD
 // systems.
+//
+// # Windows notes
+//
+// Paths can be added as "C:\\path\\to\\dir", but forward slashes
+// ("C:/path/to/dir") will also work.
+//
+// The default buffer size is 64K, which is the largest value that is guaranteed
+// to work with SMB filesystems. If you have many events in quick succession
+// this may not be enough, and you will have to use [WithBufferSize] to increase
+// the value.
 EOF
 )
 

--- a/mkdoc.zsh
+++ b/mkdoc.zsh
@@ -118,8 +118,8 @@ remove=$(<<EOF
 // Remove stops monitoring the path for changes.
 //
 // If the path was added as a recursive watch (e.g. as "/tmp/dir/...") then the
-// entire recusrice watch will be removed. You can use both "/tmp/dir" and
-// "/tmp/dir/..." (they behave identical).
+// entire recursive watch will be removed. You can use either "/tmp/dir" or
+// "/tmp/dir/..." (they behave identically).
 //
 // You cannot remove individual files or subdirectories from recursive watches;
 // e.g. Add("/tmp/path/...") and then Remove("/tmp/path/sub") will fail.


### PR DESCRIPTION
Recursive watches can be added by using a "/..." parameter, similar to the Go command:

	w.Add("dir")         // Behaves as before.
	w.Add("dir/...")     // Watch dir and all paths underneath it.

	w.Remove("dir")      // Remove the watch for dir and, if
	                     // recursive, all paths underneath it too

	w.Remove("dir/...")  // Behaves like just "dir" if the path was
	                     // recursive, error otherwise (probably
	                     // want to add recursive remove too at some
	                     // point).

The advantage of using "/..." vs. an option is that it can be easily specified in configuration files and the like; for example from a TOML file:

	[watches]
	dirs = ["/tmp/one", "/tmp/two/..."]

Options for this were previously discussed at:
https://github.com/fsnotify/fsnotify/pull/339#discussion_r788246013

This should be expanded to other backends too; I started with Windows because the implementation is the both the easiest and has the least amount of control (just setting a boolean parameter), and we can focus mostly on writing tests and documentation and the for it, and we can then match the inotify and kqueue behaviour to the Windows one.

Fixes #21