### PR TITLE
inotify: simplify bookkeeping of watched paths

### DIFF
--- a/backend_inotify_test.go
+++ b/backend_inotify_test.go
@@ -117,11 +117,8 @@ func TestRemoveState(t *testing.T) {
 
 	check := func(want int) {
 		t.Helper()
-		if len(w.watches) != want {
+		if w.watches.len() != want {
 			t.Error(w.watches)
-		}
-		if len(w.paths) != want {
-			t.Error(w.paths)
 		}
 	}
 

--- a/fsnotify_test.go
+++ b/fsnotify_test.go
@@ -1503,7 +1503,7 @@ func BenchmarkWatch(b *testing.B) {
 					wg.Done()
 					return
 				}
-				b.Fatal(err)
+				b.Error(err)
 			case _, ok := <-w.Events:
 				if !ok {
 					wg.Done()


### PR DESCRIPTION
Create a new watches type to keep track of the watches instead of keeping two maps on the Watcher and accessing these directly.

This makes the bookkeeping a bit easier to follow, and we no longer need to worry about locking map access as the watcher type takes care of that now.

Came up in #472 where I want to keep track if a path was added recursively, and this makes that a bit easier.

Also seems a bit faster:

	BenchmarkWatch-2          903709              7122 ns/op             194 B/op          3 allocs/op
	BenchmarkWatch-2          923980              6322 ns/op             196 B/op          3 allocs/op

Although that benchmark is very simple and only tests one code path; just want to make sure it's not a horrible regression.