### PR TITLE
Test adding a path more than once; update documentation

### DIFF
--- a/backend_fen.go
+++ b/backend_fen.go
@@ -197,8 +197,8 @@ func (w *Watcher) Close() error {
 
 // Add starts monitoring the path for changes.
 //
-// A path can only be watched once; attempting to watch it more than once will
-// return an error. Paths that do not yet exist on the filesystem cannot be
+// A path can only be watched once; watching it more than once is a no-op and will
+// not return an error. Paths that do not yet exist on the filesystem cannot
 // watched.
 //
 // A watch will be automatically removed if the watched path is deleted or

--- a/backend_inotify.go
+++ b/backend_inotify.go
@@ -307,8 +307,8 @@ func (w *Watcher) Close() error {
 
 // Add starts monitoring the path for changes.
 //
-// A path can only be watched once; attempting to watch it more than once will
-// return an error. Paths that do not yet exist on the filesystem cannot be
+// A path can only be watched once; watching it more than once is a no-op and will
+// not return an error. Paths that do not yet exist on the filesystem cannot
 // watched.
 //
 // A watch will be automatically removed if the watched path is deleted or

--- a/backend_kqueue.go
+++ b/backend_kqueue.go
@@ -250,8 +250,8 @@ func (w *Watcher) Close() error {
 
 // Add starts monitoring the path for changes.
 //
-// A path can only be watched once; attempting to watch it more than once will
-// return an error. Paths that do not yet exist on the filesystem cannot be
+// A path can only be watched once; watching it more than once is a no-op and will
+// not return an error. Paths that do not yet exist on the filesystem cannot
 // watched.
 //
 // A watch will be automatically removed if the watched path is deleted or

--- a/backend_other.go
+++ b/backend_other.go
@@ -132,8 +132,8 @@ func (w *Watcher) WatchList() []string { return nil }
 
 // Add starts monitoring the path for changes.
 //
-// A path can only be watched once; attempting to watch it more than once will
-// return an error. Paths that do not yet exist on the filesystem cannot be
+// A path can only be watched once; watching it more than once is a no-op and will
+// not return an error. Paths that do not yet exist on the filesystem cannot
 // watched.
 //
 // A watch will be automatically removed if the watched path is deleted or

--- a/backend_windows.go
+++ b/backend_windows.go
@@ -210,8 +210,8 @@ func (w *Watcher) Close() error {
 
 // Add starts monitoring the path for changes.
 //
-// A path can only be watched once; attempting to watch it more than once will
-// return an error. Paths that do not yet exist on the filesystem cannot be
+// A path can only be watched once; watching it more than once is a no-op and will
+// not return an error. Paths that do not yet exist on the filesystem cannot
 // watched.
 //
 // A watch will be automatically removed if the watched path is deleted or

--- a/fsnotify_test.go
+++ b/fsnotify_test.go
@@ -1203,6 +1203,26 @@ func TestAdd(t *testing.T) {
 			t.Errorf("not syscall.EACCESS: %T %#[1]v", err)
 		}
 	})
+
+	t.Run("add same path twice", func(t *testing.T) {
+		tmp := t.TempDir()
+		w := newCollector(t)
+		if err := w.w.Add(tmp); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.w.Add(tmp); err != nil {
+			t.Fatal(err)
+		}
+
+		w.collect(t)
+		touch(t, tmp, "file")
+		rm(t, tmp, "file")
+
+		cmpEvents(t, tmp, w.events(t), newEvents(t, `
+			create /file
+			remove /file
+		`))
+	})
 }
 
 // TODO: should also check internal state is correct/cleaned up; e.g. no

--- a/mkdoc.zsh
+++ b/mkdoc.zsh
@@ -77,8 +77,8 @@ EOF
 add=$(<<EOF
 // Add starts monitoring the path for changes.
 //
-// A path can only be watched once; attempting to watch it more than once will
-// return an error. Paths that do not yet exist on the filesystem cannot be
+// A path can only be watched once; watching it more than once is a no-op and will
+// not return an error. Paths that do not yet exist on the filesystem cannot
 // watched.
 //
 // A watch will be automatically removed if the watched path is deleted or


### PR DESCRIPTION
Seems like this doesn't return an error with any backend. Maybe it
should, but we can't really change it because it's not compatible. I
tested with v1.5.4 and v1.4.8 too to make sure it's not a recent
regression, and it behaves identical there too.

Fixes #548
