### PR TITLE
Optional Buffered Events channel.

### DIFF
--- a/backend_fen.go
+++ b/backend_fen.go
@@ -136,7 +136,14 @@ func NewWatcher() (*Watcher, error) {
 	return NewBufferedWatcher(0)
 }
 
-// NewBufferedWatcher creates a new Watcher with an optionally buffered Event channel
+// NewBufferedWatcher creates a new Watcher with an optionally buffered event channel.
+// For almost all use cases an unbuffered Watcher will perform better than buffered.
+// Most kernels have de-duplication logic which allows for less activity in userspace
+// and generally better performance.  However there may be some cases where a very
+// large buffers can enable an application to keep up with mass file rotations.
+// You will always be better off increasing the kernel buffers over adding a large
+// userspace buffer, but if you can't control the kernel buffer then a buffered
+// watcher is a reasonable option.  You probably want NewWatcher.
 func NewBufferedWatcher(sz uint) (*Watcher, error) {
 	w := &Watcher{
 		Events:  make(chan Event, sz),

--- a/backend_fen.go
+++ b/backend_fen.go
@@ -133,8 +133,13 @@ type Watcher struct {
 
 // NewWatcher creates a new Watcher.
 func NewWatcher() (*Watcher, error) {
+	return NewBufferedWatcher(0)
+}
+
+// NewBufferedWatcher creates a new Watcher with an optionally buffered Event channel
+func NewBufferedWatcher(sz uint) (*Watcher, error) {
 	w := &Watcher{
-		Events:  make(chan Event),
+		Events:  make(chan Event, sz),
 		Errors:  make(chan error),
 		dirs:    make(map[string]struct{}),
 		watches: make(map[string]struct{}),

--- a/backend_inotify.go
+++ b/backend_inotify.go
@@ -235,7 +235,14 @@ func NewWatcher() (*Watcher, error) {
 	return NewBufferedWatcher(0)
 }
 
-// NewBufferedWatcher creates a new Watcher with an optionally buffered Event channel
+// NewBufferedWatcher creates a new Watcher with an optionally buffered event channel.
+// For almost all use cases an unbuffered Watcher will perform better than buffered.
+// Most kernels have de-duplication logic which allows for less activity in userspace
+// and generally better performance.  However there may be some cases where a very
+// large buffers can enable an application to keep up with mass file rotations.
+// You will always be better off increasing the kernel buffers over adding a large
+// userspace buffer, but if you can't control the kernel buffer then a buffered
+// watcher is a reasonable option.  You probably want NewWatcher.
 func NewBufferedWatcher(sz uint) (*Watcher, error) {
 	// Need to set nonblocking mode for SetDeadline to work, otherwise blocking
 	// I/O operations won't terminate on close.

--- a/backend_inotify.go
+++ b/backend_inotify.go
@@ -232,6 +232,11 @@ func (w *watches) updatePath(path string, f func(*watch) (*watch, error)) error 
 
 // NewWatcher creates a new Watcher.
 func NewWatcher() (*Watcher, error) {
+	return NewBufferedWatcher(0)
+}
+
+// NewBufferedWatcher creates a new Watcher with an optionally buffered Event channel
+func NewBufferedWatcher(sz uint) (*Watcher, error) {
 	// Need to set nonblocking mode for SetDeadline to work, otherwise blocking
 	// I/O operations won't terminate on close.
 	fd, errno := unix.InotifyInit1(unix.IN_CLOEXEC | unix.IN_NONBLOCK)
@@ -243,7 +248,7 @@ func NewWatcher() (*Watcher, error) {
 		fd:          fd,
 		inotifyFile: os.NewFile(uintptr(fd), ""),
 		watches:     newWatches(),
-		Events:      make(chan Event),
+		Events:      make(chan Event, sz),
 		Errors:      make(chan error),
 		done:        make(chan struct{}),
 		doneResp:    make(chan struct{}),

--- a/backend_kqueue.go
+++ b/backend_kqueue.go
@@ -147,7 +147,14 @@ func NewWatcher() (*Watcher, error) {
 	return NewBufferedWatcher(0)
 }
 
-// NewBufferedWatcher creates a new Watcher with an optionally buffered Event channel
+// NewBufferedWatcher creates a new Watcher with an optionally buffered event channel.
+// For almost all use cases an unbuffered Watcher will perform better than buffered.
+// Most kernels have de-duplication logic which allows for less activity in userspace
+// and generally better performance.  However there may be some cases where a very
+// large buffers can enable an application to keep up with mass file rotations.
+// You will always be better off increasing the kernel buffers over adding a large
+// userspace buffer, but if you can't control the kernel buffer then a buffered
+// watcher is a reasonable option.  You probably want NewWatcher.
 func NewBufferedWatcher(sz uint) (*Watcher, error) {
 	kq, closepipe, err := newKqueue()
 	if err != nil {

--- a/backend_kqueue.go
+++ b/backend_kqueue.go
@@ -144,6 +144,11 @@ type pathInfo struct {
 
 // NewWatcher creates a new Watcher.
 func NewWatcher() (*Watcher, error) {
+	return NewBufferedWatcher(0)
+}
+
+// NewBufferedWatcher creates a new Watcher with an optionally buffered Event channel
+func NewBufferedWatcher(sz uint) (*Watcher, error) {
 	kq, closepipe, err := newKqueue()
 	if err != nil {
 		return nil, err
@@ -158,7 +163,7 @@ func NewWatcher() (*Watcher, error) {
 		paths:        make(map[int]pathInfo),
 		fileExists:   make(map[string]struct{}),
 		userWatches:  make(map[string]struct{}),
-		Events:       make(chan Event),
+		Events:       make(chan Event, sz),
 		Errors:       make(chan error),
 		done:         make(chan struct{}),
 	}

--- a/backend_other.go
+++ b/backend_other.go
@@ -122,6 +122,11 @@ func NewWatcher() (*Watcher, error) {
 	return nil, errors.New("fsnotify not supported on the current platform")
 }
 
+// NewBufferedWatcher creates a new Watcher with an optionally buffered Event channel
+func NewBufferedWatcher(sz uint) (*Watcher, error) {
+	return NewWatcher() //just re-use the original error response
+}
+
 // Close removes all watches and closes the events channel.
 func (w *Watcher) Close() error { return nil }
 

--- a/backend_other.go
+++ b/backend_other.go
@@ -122,7 +122,14 @@ func NewWatcher() (*Watcher, error) {
 	return nil, errors.New("fsnotify not supported on the current platform")
 }
 
-// NewBufferedWatcher creates a new Watcher with an optionally buffered Event channel
+// NewBufferedWatcher creates a new Watcher with an optionally buffered event channel.
+// For almost all use cases an unbuffered Watcher will perform better than buffered.
+// Most kernels have de-duplication logic which allows for less activity in userspace
+// and generally better performance.  However there may be some cases where a very
+// large buffers can enable an application to keep up with mass file rotations.
+// You will always be better off increasing the kernel buffers over adding a large
+// userspace buffer, but if you can't control the kernel buffer then a buffered
+// watcher is a reasonable option.  You probably want NewWatcher.
 func NewBufferedWatcher(sz uint) (*Watcher, error) {
 	return NewWatcher() //just re-use the original error response
 }

--- a/backend_windows.go
+++ b/backend_windows.go
@@ -146,7 +146,14 @@ func NewWatcher() (*Watcher, error) {
 	return NewBufferedWatcher(50) // Windows backend defaults to a buffered channel of size 50
 }
 
-// NewBufferedWatcher creates a new Watcher with an optionally buffered Event channel
+// NewBufferedWatcher creates a new Watcher with an optionally buffered event channel.
+// For almost all use cases an unbuffered Watcher will perform better than buffered.
+// Most kernels have de-duplication logic which allows for less activity in userspace
+// and generally better performance.  However there may be some cases where a very
+// large buffers can enable an application to keep up with mass file rotations.
+// You will always be better off increasing the kernel buffers over adding a large
+// userspace buffer, but if you can't control the kernel buffer then a buffered
+// watcher is a reasonable option.  You probably want NewWatcher.
 func NewBufferedWatcher(sz uint) (*Watcher, error) {
 	port, err := windows.CreateIoCompletionPort(windows.InvalidHandle, 0, 0, 0)
 	if err != nil {

--- a/backend_windows.go
+++ b/backend_windows.go
@@ -143,6 +143,11 @@ type Watcher struct {
 
 // NewWatcher creates a new Watcher.
 func NewWatcher() (*Watcher, error) {
+	return NewBufferedWatcher(50) // Windows backend defaults to a buffered channel of size 50
+}
+
+// NewBufferedWatcher creates a new Watcher with an optionally buffered Event channel
+func NewBufferedWatcher(sz uint) (*Watcher, error) {
 	port, err := windows.CreateIoCompletionPort(windows.InvalidHandle, 0, 0, 0)
 	if err != nil {
 		return nil, os.NewSyscallError("CreateIoCompletionPort", err)
@@ -151,7 +156,7 @@ func NewWatcher() (*Watcher, error) {
 		port:    port,
 		watches: make(watchMap),
 		input:   make(chan *input, 1),
-		Events:  make(chan Event, 50),
+		Events:  make(chan Event, sz),
 		Errors:  make(chan error),
 		quit:    make(chan chan<- error, 1),
 	}

--- a/mkdoc.zsh
+++ b/mkdoc.zsh
@@ -75,6 +75,13 @@ EOF
 
 newbuffered=$(<<EOF
 // NewBufferedWatcher creates a new Watcher with an optionally buffered event channel.
+// For almost all use cases an unbuffered Watcher will perform better than buffered.
+// Most kernels have de-duplication logic which allows for less activity in userspace
+// and generally better performance.  However there may be some cases where a very
+// large buffers can enable an application to keep up with mass file rotations.
+// You will always be better off increasing the kernel buffers over adding a large
+// userspace buffer, but if you can't control the kernel buffer then a buffered
+// watcher is a reasonable option.  You probably want NewWatcher.
 EOF
 )
 

--- a/mkdoc.zsh
+++ b/mkdoc.zsh
@@ -72,6 +72,10 @@ EOF
 new=$(<<EOF
 // NewWatcher creates a new Watcher.
 EOF
+
+newbuffered=$(<<EOF
+// NewBufferedWatcher creates a new Watcher with an optionally buffered event channel.
+EOF
 )
 
 add=$(<<EOF
@@ -236,6 +240,7 @@ set-cmt() {
 
 set-cmt '^type Watcher struct '             $watcher
 set-cmt '^func NewWatcher('                 $new
+set-cmt '^func NewBufferedWatcher('         $newbuffered
 set-cmt '^func (w \*Watcher) Add('          $add
 set-cmt '^func (w \*Watcher) AddWith('      $addwith
 set-cmt '^func (w \*Watcher) Remove('       $remove


### PR DESCRIPTION
This PR slightly overhauls the NewWatcher() API so that a list of Options functions can be provided.  Currently there is only one configured option but there are a few issues asking for more configuration options so this should allow for an extensible method to add configuration options to NewWatcher.

### The goals for this PR:

1. Do not change the API in any way that would require any refactor by users of the library.
2. Make all options optional and ensure default behavior is unchanged.
3. Provide the option to configure a userland buffer in the event channel.

### The motivation for this PR

We make extensive use of the fsnotify library but continually run into situations with older RedHat installations where the kernel fsnotify buffer is not large enough to accommodate high load scenarios like log file rotation and the end user cannot modify the kernel parameters.  We have been running a fork that created a userland event channel buffer and  found that we are able to deal with very large bursts of fsnotify events without being forced to catch errors and recover.

The userland channel buffer will never be as fast as the kernel buffer, and in most cases straight won't be used, but this PR gives users of the library the option to add some padding without changing kernel parameters.