### PR TITLE
Fix: Ordering of channel closure

### DIFF
--- a/backend_inotify.go
+++ b/backend_inotify.go
@@ -452,9 +452,9 @@ func (w *Watcher) WatchList() []string {
 // received events into Event objects and sends them via the Events channel
 func (w *Watcher) readEvents() {
 	defer func() {
-		close(w.doneResp)
-		close(w.Errors)
 		close(w.Events)
+		close(w.Errors)
+		close(w.doneResp)
 	}()
 
 	var (

--- a/backend_inotify_test.go
+++ b/backend_inotify_test.go
@@ -134,38 +134,3 @@ func TestRemoveState(t *testing.T) {
 	}
 	check(0)
 }
-
-func TestInotifyCloseOrder(t *testing.T) {
-	t.Parallel()
-
-	var (
-		tmp = t.TempDir()
-	)
-
-	w := newWatcher(t, tmp)
-	addWatch(t, w, tmp)
-
-	c := make(chan struct{})
-
-	var closed bool
-	go func() {
-		select {
-		case _, ok := <-w.Events:
-			if !ok {
-				closed = true
-			}
-		case _, ok := <-w.Errors:
-			_ = ok
-		}
-		close(c)
-	}()
-
-	time.Sleep(1 * time.Second)
-	w.Close()
-
-	<-c
-
-	if !closed {
-		t.Error("events was not closed")
-	}
-}


### PR DESCRIPTION
We updated `fsnotify` to `1.6.0` internally there today and noticed some of our test cases were failing.

We listen for the closure of `Events` in a `select` statement to know when some file operation has been completed. However, in this `select` we also listen for the closure of `Errors` just incase.

In `v1.5.4` all closures were [handled in their own defer](https://github.com/fsnotify/fsnotify/blob/v1.5.4/inotify.go#L195-L196), in `v1.6.0` these closures are handled in a single defer. However this causes a change in behaviour that I am not sure is intentional. Defers are handled in reverse order so `Events` was closed before `Errors`, but now as the order of the closure wasn't flipped, so now signals are sent in reverse order.

So, `doneResp` returns (and thus `Close() error`) before all closing functionality has been completed.

This just flips the ordering back to how it was in previous versions.