### PR TITLE
Pin golang.org/x/sys

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/fsnotify/fsnotify
 
 go 1.17
 
-require golang.org/x/sys v0.0.0-20220908164124-27713097b956
+require golang.org/x/sys v0.4.0
 
 retract (
 	v1.5.3 // Published an incorrect branch accidentally https://github.com/fsnotify/fsnotify/issues/445

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.0.0-20220908164124-27713097b956 h1:XeJjHH1KiLpKGb6lvMiksZ9l0fVUh+AmGcm0nOMEBOY=
-golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.4.0 h1:Zr2JFtRQNX3BCZ8YtxRE9hNJYC8J6I1MVbMg6owUp18=
+golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
Pinning this module to a proper version as it was causing me issues due to the pretty old version of `x/sys` in `go.mod`. Tests are passing, vet is clean, and `fmt` is good.