### PR TITLE
Update CI to Go 1.17 - 1.20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.16', '1.19']
+        go: ['1.17', '1.20']
     runs-on: ubuntu-latest
     steps:
       - name: setup Go

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,8 @@ jobs:
           - ubuntu-latest
           - windows-latest
         go:
-          - '1.16'
-          - '1.19'
+          - '1.17'
+          - '1.20'
     runs-on: ${{ matrix.os }}
     steps:
       - name: setup Go
@@ -46,7 +46,7 @@ jobs:
 
   # Test only the latest Go version on macOS; we use the macOS builders for BSD
   # and illumos, and GitHub doesn't allow many of them to run concurrently. If
-  # it works on Windows and Linux with Go 1.16, then it probably does on macOS
+  # it works on Windows and Linux with Go 1.17, then it probably does on macOS
   # too.
   testMacOS:
     name: test
@@ -57,7 +57,7 @@ jobs:
           - macos-11
           - macos-12
         go:
-          - '1.19'
+          - '1.20'
     runs-on: ${{ matrix.os }}
     steps:
       - name: setup Go

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Unreleased
 ----------
+This version of fsnotify needs Go 1.17.
 
 ### Additions
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fsnotify/fsnotify
 
-go 1.16
+go 1.17
 
 require golang.org/x/sys v0.0.0-20220908164124-27713097b956
 


### PR DESCRIPTION
I have no idea if anyone is using Go 1.16 with fsnotify.

Go 1.16 (released August 2021) became mandatory with v1.5.1 (August 2021). Go 1.17 was released just a few days before it was tagged. Some people did experience problems (#400), but overall the feedback was limited.

So based on this, I think it's probably safe to just follow the Go release policy: "Each major Go release is supported until there are two newer major releases."

This will allow merging #554