### PR TITLE
Run iOS tests against newer Go version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
   # iOS
   ios:
     macos:
-      xcode: 12.5.1
+      xcode: 13.4.1
     working_directory: ~/repo
     steps:
       - checkout


### PR DESCRIPTION
Was still using Go 1.16. Just update the image: updating Homebrew takes
~2 minutes and slows down the CI a lot.