### PR TITLE
bump actions/setup-go v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,13 +13,13 @@ jobs:
         go: ['1.17', '1.20']
     runs-on: ubuntu-latest
     steps:
-      - name: setup Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: ${{ matrix.go }}
-
       - name: checkout
         uses: actions/checkout@v3
+
+      - name: setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ matrix.go }}
 
       - name: build
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,13 +19,13 @@ jobs:
           - '1.20'
     runs-on: ${{ matrix.os }}
     steps:
-      - name: setup Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: ${{ matrix.go }}
-
       - name: checkout
         uses: actions/checkout@v3
+
+      - name: setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ matrix.go }}
 
       - name: test
         run: |
@@ -60,13 +60,13 @@ jobs:
           - '1.20'
     runs-on: ${{ matrix.os }}
     steps:
-      - name: setup Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: ${{ matrix.go }}
-
       - name: checkout
         uses: actions/checkout@v3
+
+      - name: setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ matrix.go }}
 
       - name: test
         run: |
@@ -114,7 +114,7 @@ jobs:
     runs-on: macos-12
     name: test (illumos, 1.19)
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: test (illumos, 1.19)
       id: test
       uses: papertigers/illumos-vm@r38
@@ -145,7 +145,7 @@ jobs:
             ${{ runner.os }}-vagrant-
 
       - name: setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: '1.19'
 


### PR DESCRIPTION
`actions/setup-go@v4` has been released.

- https://github.com/actions/setup-go/releases/tag/v4.0.0
