### PR TITLE
Remove the Windows "recursive" backend for now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,6 @@ This version of fsnotify needs Go 1.17.
 - all: add `AddWith()`, which is identical to `Add()` but allows passing
   options. ([#521])
 
-- all: support recursively watching paths with `Add("path/...")`. ([#540])
-
 - windows: allow setting the buffer size with `fsnotify.WithBufferSize()`; the
   default of 64K is the highest value that works on all platforms and is enough
   for most purposes, but in some cases a highest buffer is needed. ([#521])
@@ -69,7 +67,6 @@ This version of fsnotify needs Go 1.17.
 [#526]: https://github.com/fsnotify/fsnotify/pull/526
 [#528]: https://github.com/fsnotify/fsnotify/pull/528
 [#537]: https://github.com/fsnotify/fsnotify/pull/537
-[#540]: https://github.com/fsnotify/fsnotify/pull/540
 
 1.6.0 - 2022-10-13
 -------------------

--- a/backend_fen.go
+++ b/backend_fen.go
@@ -215,9 +215,8 @@ func (w *Watcher) Close() error {
 // # Watching directories
 //
 // All files in a directory are monitored, including new files that are created
-// after the watcher is started. By default subdirectories are not watched (i.e.
-// it's non-recursive), but if the path ends with "/..." all files and
-// subdirectories are watched too.
+// after the watcher is started. Subdirectories are not watched (i.e. it's
+// non-recursive).
 //
 // # Watching files
 //
@@ -282,15 +281,8 @@ func (w *Watcher) AddWith(name string, opts ...addOpt) error {
 
 // Remove stops monitoring the path for changes.
 //
-// If the path was added as a recursive watch (e.g. as "/tmp/dir/...") then the
-// entire recursive watch will be removed. You can use either "/tmp/dir" or
-// "/tmp/dir/..." (they behave identically).
-//
-// You cannot remove individual files or subdirectories from recursive watches;
-// e.g. Add("/tmp/path/...") and then Remove("/tmp/path/sub") will fail.
-//
-// For other watches directories are removed non-recursively. For example, if
-// you added "/tmp/dir" and "/tmp/dir/subdir" then you will need to remove both.
+// Directories are always removed non-recursively. For example, if you added
+// /tmp/dir and /tmp/dir/subdir then you will need to remove both.
 //
 // Removing a path that has not yet been added returns [ErrNonExistentWatch].
 //

--- a/backend_inotify.go
+++ b/backend_inotify.go
@@ -325,9 +325,8 @@ func (w *Watcher) Close() error {
 // # Watching directories
 //
 // All files in a directory are monitored, including new files that are created
-// after the watcher is started. By default subdirectories are not watched (i.e.
-// it's non-recursive), but if the path ends with "/..." all files and
-// subdirectories are watched too.
+// after the watcher is started. Subdirectories are not watched (i.e. it's
+// non-recursive).
 //
 // # Watching files
 //
@@ -387,15 +386,8 @@ func (w *Watcher) AddWith(name string, opts ...addOpt) error {
 
 // Remove stops monitoring the path for changes.
 //
-// If the path was added as a recursive watch (e.g. as "/tmp/dir/...") then the
-// entire recursive watch will be removed. You can use either "/tmp/dir" or
-// "/tmp/dir/..." (they behave identically).
-//
-// You cannot remove individual files or subdirectories from recursive watches;
-// e.g. Add("/tmp/path/...") and then Remove("/tmp/path/sub") will fail.
-//
-// For other watches directories are removed non-recursively. For example, if
-// you added "/tmp/dir" and "/tmp/dir/subdir" then you will need to remove both.
+// Directories are always removed non-recursively. For example, if you added
+// /tmp/dir and /tmp/dir/subdir then you will need to remove both.
 //
 // Removing a path that has not yet been added returns [ErrNonExistentWatch].
 //

--- a/backend_kqueue.go
+++ b/backend_kqueue.go
@@ -268,9 +268,8 @@ func (w *Watcher) Close() error {
 // # Watching directories
 //
 // All files in a directory are monitored, including new files that are created
-// after the watcher is started. By default subdirectories are not watched (i.e.
-// it's non-recursive), but if the path ends with "/..." all files and
-// subdirectories are watched too.
+// after the watcher is started. Subdirectories are not watched (i.e. it's
+// non-recursive).
 //
 // # Watching files
 //
@@ -304,15 +303,8 @@ func (w *Watcher) AddWith(name string, opts ...addOpt) error {
 
 // Remove stops monitoring the path for changes.
 //
-// If the path was added as a recursive watch (e.g. as "/tmp/dir/...") then the
-// entire recursive watch will be removed. You can use either "/tmp/dir" or
-// "/tmp/dir/..." (they behave identically).
-//
-// You cannot remove individual files or subdirectories from recursive watches;
-// e.g. Add("/tmp/path/...") and then Remove("/tmp/path/sub") will fail.
-//
-// For other watches directories are removed non-recursively. For example, if
-// you added "/tmp/dir" and "/tmp/dir/subdir" then you will need to remove both.
+// Directories are always removed non-recursively. For example, if you added
+// /tmp/dir and /tmp/dir/subdir then you will need to remove both.
 //
 // Removing a path that has not yet been added returns [ErrNonExistentWatch].
 //

--- a/backend_other.go
+++ b/backend_other.go
@@ -150,9 +150,8 @@ func (w *Watcher) WatchList() []string { return nil }
 // # Watching directories
 //
 // All files in a directory are monitored, including new files that are created
-// after the watcher is started. By default subdirectories are not watched (i.e.
-// it's non-recursive), but if the path ends with "/..." all files and
-// subdirectories are watched too.
+// after the watcher is started. Subdirectories are not watched (i.e. it's
+// non-recursive).
 //
 // # Watching files
 //
@@ -178,15 +177,8 @@ func (w *Watcher) AddWith(name string, opts ...addOpt) error { return nil }
 
 // Remove stops monitoring the path for changes.
 //
-// If the path was added as a recursive watch (e.g. as "/tmp/dir/...") then the
-// entire recursive watch will be removed. You can use either "/tmp/dir" or
-// "/tmp/dir/..." (they behave identically).
-//
-// You cannot remove individual files or subdirectories from recursive watches;
-// e.g. Add("/tmp/path/...") and then Remove("/tmp/path/sub") will fail.
-//
-// For other watches directories are removed non-recursively. For example, if
-// you added "/tmp/dir" and "/tmp/dir/subdir" then you will need to remove both.
+// Directories are always removed non-recursively. For example, if you added
+// /tmp/dir and /tmp/dir/subdir then you will need to remove both.
 //
 // Removing a path that has not yet been added returns [ErrNonExistentWatch].
 //

--- a/backend_windows.go
+++ b/backend_windows.go
@@ -228,9 +228,8 @@ func (w *Watcher) Close() error {
 // # Watching directories
 //
 // All files in a directory are monitored, including new files that are created
-// after the watcher is started. By default subdirectories are not watched (i.e.
-// it's non-recursive), but if the path ends with "/..." all files and
-// subdirectories are watched too.
+// after the watcher is started. Subdirectories are not watched (i.e. it's
+// non-recursive).
 //
 // # Watching files
 //
@@ -278,15 +277,8 @@ func (w *Watcher) AddWith(name string, opts ...addOpt) error {
 
 // Remove stops monitoring the path for changes.
 //
-// If the path was added as a recursive watch (e.g. as "/tmp/dir/...") then the
-// entire recursive watch will be removed. You can use either "/tmp/dir" or
-// "/tmp/dir/..." (they behave identically).
-//
-// You cannot remove individual files or subdirectories from recursive watches;
-// e.g. Add("/tmp/path/...") and then Remove("/tmp/path/sub") will fail.
-//
-// For other watches directories are removed non-recursively. For example, if
-// you added "/tmp/dir" and "/tmp/dir/subdir" then you will need to remove both.
+// Directories are always removed non-recursively. For example, if you added
+// /tmp/dir and /tmp/dir/subdir then you will need to remove both.
 //
 // Removing a path that has not yet been added returns [ErrNonExistentWatch].
 //
@@ -470,7 +462,9 @@ func (m watchMap) set(ino *inode, watch *watch) {
 
 // Must run within the I/O thread.
 func (w *Watcher) addWatch(pathname string, flags uint64, bufsize int) error {
-	pathname, recurse := recursivePath(pathname)
+	//pathname, recurse := recursivePath(pathname)
+	recurse := false
+
 	dir, err := w.getDir(pathname)
 	if err != nil {
 		return err

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -595,8 +595,8 @@ func isSolaris() bool {
 
 func recurseOnly(t *testing.T) {
 	switch runtime.GOOS {
-	case "windows":
-		// Run test.
+	//case "windows":
+	// Run test.
 	default:
 		t.Skip("recursion not yet supported on " + runtime.GOOS)
 	}

--- a/mkdoc.zsh
+++ b/mkdoc.zsh
@@ -95,9 +95,8 @@ add=$(<<EOF
 // # Watching directories
 //
 // All files in a directory are monitored, including new files that are created
-// after the watcher is started. By default subdirectories are not watched (i.e.
-// it's non-recursive), but if the path ends with "/..." all files and
-// subdirectories are watched too.
+// after the watcher is started. Subdirectories are not watched (i.e. it's
+// non-recursive).
 //
 // # Watching files
 //
@@ -127,15 +126,8 @@ EOF
 remove=$(<<EOF
 // Remove stops monitoring the path for changes.
 //
-// If the path was added as a recursive watch (e.g. as "/tmp/dir/...") then the
-// entire recursive watch will be removed. You can use either "/tmp/dir" or
-// "/tmp/dir/..." (they behave identically).
-//
-// You cannot remove individual files or subdirectories from recursive watches;
-// e.g. Add("/tmp/path/...") and then Remove("/tmp/path/sub") will fail.
-//
-// For other watches directories are removed non-recursively. For example, if
-// you added "/tmp/dir" and "/tmp/dir/subdir" then you will need to remove both.
+// Directories are always removed non-recursively. For example, if you added
+// /tmp/dir and /tmp/dir/subdir then you will need to remove both.
 //
 // Removing a path that has not yet been added returns [ErrNonExistentWatch].
 //


### PR DESCRIPTION
I don't really have the time to properly implement it for inotify, kqueue, and illumos, and it seems no one else has ether.

This will allow us to release a new version, which includes many bugfixes.