### PR TITLE
Document and test removing watched directory on Windows

### DIFF
--- a/backend_fen.go
+++ b/backend_fen.go
@@ -72,6 +72,11 @@ import (
 // Paths can be added as "C:\path\to\dir", but forward slashes
 // ("C:/path/to/dir") will also work.
 //
+// When a watched directory is removed it will always send an event for the
+// directory itself, but may not send events for all files in that directory.
+// Sometimes it will send events for all times, sometimes it will send no
+// events, and often only for some files. 
+//
 // The default buffer size is 64K, which is the largest value that is guaranteed
 // to work with SMB filesystems. If you have many events in quick succession
 // this may not be enough, and you will have to use [WithBufferSize] to increase

--- a/backend_inotify.go
+++ b/backend_inotify.go
@@ -75,6 +75,11 @@ import (
 // Paths can be added as "C:\path\to\dir", but forward slashes
 // ("C:/path/to/dir") will also work.
 //
+// When a watched directory is removed it will always send an event for the
+// directory itself, but may not send events for all files in that directory.
+// Sometimes it will send events for all times, sometimes it will send no
+// events, and often only for some files. 
+//
 // The default buffer size is 64K, which is the largest value that is guaranteed
 // to work with SMB filesystems. If you have many events in quick succession
 // this may not be enough, and you will have to use [WithBufferSize] to increase

--- a/backend_kqueue.go
+++ b/backend_kqueue.go
@@ -72,6 +72,11 @@ import (
 // Paths can be added as "C:\path\to\dir", but forward slashes
 // ("C:/path/to/dir") will also work.
 //
+// When a watched directory is removed it will always send an event for the
+// directory itself, but may not send events for all files in that directory.
+// Sometimes it will send events for all times, sometimes it will send no
+// events, and often only for some files. 
+//
 // The default buffer size is 64K, which is the largest value that is guaranteed
 // to work with SMB filesystems. If you have many events in quick succession
 // this may not be enough, and you will have to use [WithBufferSize] to increase

--- a/backend_other.go
+++ b/backend_other.go
@@ -64,6 +64,11 @@ import "errors"
 // Paths can be added as "C:\path\to\dir", but forward slashes
 // ("C:/path/to/dir") will also work.
 //
+// When a watched directory is removed it will always send an event for the
+// directory itself, but may not send events for all files in that directory.
+// Sometimes it will send events for all times, sometimes it will send no
+// events, and often only for some files. 
+//
 // The default buffer size is 64K, which is the largest value that is guaranteed
 // to work with SMB filesystems. If you have many events in quick succession
 // this may not be enough, and you will have to use [WithBufferSize] to increase

--- a/backend_windows.go
+++ b/backend_windows.go
@@ -80,6 +80,11 @@ import (
 // Paths can be added as "C:\path\to\dir", but forward slashes
 // ("C:/path/to/dir") will also work.
 //
+// When a watched directory is removed it will always send an event for the
+// directory itself, but may not send events for all files in that directory.
+// Sometimes it will send events for all times, sometimes it will send no
+// events, and often only for some files. 
+//
 // The default buffer size is 64K, which is the largest value that is guaranteed
 // to work with SMB filesystems. If you have many events in quick succession
 // this may not be enough, and you will have to use [WithBufferSize] to increase

--- a/mkdoc.zsh
+++ b/mkdoc.zsh
@@ -62,6 +62,11 @@ watcher=$(<<EOF
 // Paths can be added as "C:\\path\\to\\dir", but forward slashes
 // ("C:/path/to/dir") will also work.
 //
+// When a watched directory is removed it will always send an event for the
+// directory itself, but may not send events for all files in that directory.
+// Sometimes it will send events for all times, sometimes it will send no
+// events, and often only for some files. 
+//
 // The default buffer size is 64K, which is the largest value that is guaranteed
 // to work with SMB filesystems. If you have many events in quick succession
 // this may not be enough, and you will have to use [WithBufferSize] to increase


### PR DESCRIPTION
On Windows deleting the watched directive gives undefined results and delivering events for the files in the directory is not guaranteed. I can reproduce this even with a very simple example in Python, and it's not an fsnotify bug as far as I can see.

There's nothing we can do about this, so update the documentation and tweak the test so we don't get intermittent test failures.

On other platforms it does report all files.