### PR TITLE
kqueue: ignore events with Ident=0

### DIFF
--- a/fsnotify_test.go
+++ b/fsnotify_test.go
@@ -544,9 +544,9 @@ func TestWatchSymlink(t *testing.T) {
 
 		// Bug #277
 		{"277", func(t *testing.T, w *Watcher, tmp string) {
-			if runtime.GOOS == "netbsd" && isCI() {
-				t.Skip("fails in CI") // TODO
-			}
+			// if runtime.GOOS == "netbsd" && isCI() {
+			// 	t.Skip("fails in CI") // TODO
+			// }
 
 			// TODO: there is some strange fuckery going on if I use go test
 			// -count=2; the second test run has unix.Kqueue() in newKqueue()


### PR DESCRIPTION
On macOS it seems that sometimes an event with Ident=0 is delivered, and
no other flags/information beyond that, even though we never saw such a
file descriptor. For example in TestWatchSymlink/277 (usually at the
end, but sometimes sooner):

		# Okay, expected
		CREATE               "/foo"
		REMOVE               "/foo"
		CREATE               "/apple"
		CREATE               "/pear"
		RENAME               "/apple"
		REMOVE               "/pear"

		# One or more write events without any ident or information?!
		WRITE                ""

Printing some debug in the loop right after we receive events shows:

		unix.Kevent_t{Ident:0x2a, Filter:-4, Flags:0x25, Fflags:0x2, Data:0, Udata:(*uint8)(nil)}
		unix.Kevent_t{Ident:0x0,  Filter:-4, Flags:0x25, Fflags:0x2, Data:0, Udata:(*uint8)(nil)}

The first is a normal event, the second with Ident 0. No error flag, no
data, no ... nothing.

I read a bit through bsd/kern_event.c from the xnu source, but I don't
really see an obvious location where this is triggered – this doesn't
seem intentional, but idk...

Technically fd 0 is a valid descriptor, so only skip it if there's no
path, and if we're on macOS.
