### PR TITLE
Update BSD vmactions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,10 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest']
-        go: ['1.17', '1.21']
+        go: ['1.17', '1.22']
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: 'actions/checkout@v3'
+      - uses: 'actions/checkout@v4'
       - uses: 'actions/setup-go@v4'
         with:
           go-version: ${{ matrix.go }}
@@ -28,10 +28,10 @@ jobs:
       fail-fast: false
       matrix:
         os: ['windows-latest']
-        go: ['1.17', '1.21']
+        go: ['1.17', '1.22']
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: 'actions/checkout@v3'
+      - uses: 'actions/checkout@v4'
       - uses: 'actions/setup-go@v4'
         with:
           go-version: ${{ matrix.go }}
@@ -46,7 +46,7 @@ jobs:
     runs-on: 'ubuntu-22.04'
     name:    'test (ubuntu-22.04, gccgo 12.1)'
     steps:
-      - uses: 'actions/checkout@v3'
+      - uses: 'actions/checkout@v4'
       - name: test
         run: |
           sudo apt-get -y install gccgo-12
@@ -63,10 +63,10 @@ jobs:
       fail-fast: false
       matrix:
         os: ['macos-11', 'macos-13']
-        go: ['1.21']
+        go: ['1.22']
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: 'actions/checkout@v3'
+      - uses: 'actions/checkout@v4'
       - uses: 'actions/setup-go@v4'
         with:
           go-version: ${{ matrix.go }}
@@ -83,14 +83,13 @@ jobs:
   #       much faster race detector, so maybe waiting until we have that is
   #       enough.
   openbsd:
-    runs-on: 'macos-12'
-    timeout-minutes: 30
+    runs-on: 'ubuntu-latest'
     name: 'test (openbsd, 1.17)'
     steps:
-      - uses: 'actions/checkout@v3'
+      - uses: 'actions/checkout@v4'
       - name: 'test (openbsd, 1.17)'
         id:   'openbsd'
-        uses: 'vmactions/openbsd-vm@v0'
+        uses: 'vmactions/openbsd-vm@v1'
         with:
           prepare: pkg_add go
           run: |
@@ -100,77 +99,73 @@ jobs:
 
   # NetBSD
   netbsd:
-    runs-on: macos-12
-    timeout-minutes: 30
-    name: test (netbsd, 1.20)
+    runs-on: 'ubuntu-latest'
+    name: 'test (netbsd, 1.21)'
     steps:
-      - uses: 'actions/checkout@v3'
-      - name: 'test (netbsd, 1.20)'
+      - uses: 'actions/checkout@v4'
+      - name: 'test (netbsd, 1.21)'
         id:   'netbsd'
-        uses: 'vmactions/netbsd-vm@v0'
+        uses: 'vmactions/netbsd-vm@v1'
         with:
           prepare: pkg_add go
           # TODO: no -race for the same reason as OpenBSD (the timing; it does run).
           run: |
             useradd -mG wheel action
-            FSNOTIFY_BUFFER=4096 su action -c 'go120 test -parallel 1 ./...'
-                                 su action -c 'go120 test -parallel 1 ./...'
+            FSNOTIFY_BUFFER=4096 su action -c '/usr/pkg/bin/go??? test -parallel 1 ./...'
+                                 su action -c '/usr/pkg/bin/go??? test -parallel 1 ./...'
+
+  # DragonFlyBSD
+  dragonflybsd:
+    runs-on: 'ubuntu-latest'
+    name: 'test (dragonflybsd, 1.20)'
+    steps:
+      - uses: 'actions/checkout@v4'
+      - name: 'test (dragonflybsd, 1.20)'
+        id:   'dragonflybsd'
+        uses: 'vmactions/dragonflybsd-vm@v1'
+        with:
+          prepare: pkg install -y go
+          # TODO: no -race for the same reason as OpenBSD (the timing; it does run).
+          run: |
+            pw user add -mG wheel -n action
+            FSNOTIFY_BUFFER=4096 su action -c 'go test -parallel 1 ./...'
+                                 su action -c 'go test -parallel 1 ./...'
 
   # illumos
   illumos:
-    runs-on: macos-12
-    timeout-minutes: 30
-    name: test (illumos, 1.19)
+    runs-on: 'ubuntu-latest'
+    name: 'test (illumos, 1.22)'
     steps:
-    - uses: 'actions/checkout@v3'
-    - name: 'test (illumos, 1.19)'
+    - uses: 'actions/checkout@v4'
+    - name: 'test (illumos, 1.22)'
       id:   'illumos'
-      uses: 'papertigers/illumos-vm@r38'
+      uses: 'vmactions/omnios-vm@v1'
       with:
-        prepare: |
-          pkg install go-119
+        prepare: pkg install go-122
         run: |
           useradd action
           export GOCACHE=/tmp/go-cache
           export GOPATH=/tmp/go-path
-          FSNOTIFY_BUFFER=4096 su action -c '/opt/ooce/go-1.19/bin/go test -parallel 1 ./...'
-                               su action -c '/opt/ooce/go-1.19/bin/go test -parallel 1 ./...'
+          FSNOTIFY_BUFFER=4096 su action -c '/opt/ooce/go-1.22/bin/go test -parallel 1 ./...'
+                               su action -c '/opt/ooce/go-1.22/bin/go test -parallel 1 ./...'
 
-  # Older Debian 6, for old Linux kernels.
-  debian6:
-    runs-on: macos-12
-    timeout-minutes: 30
-    name: test (debian6, 1.19)
-    strategy:
-      fail-fast: false
-    steps:
-      - uses: actions/checkout@v3
 
-      - name: Cache Vagrant boxes
-        uses: actions/cache@v3
-        with:
-          path: ~/.vagrant.d/boxes
-          key: ${{ runner.os }}-vagrant-${{ hashFiles('Vagrantfile') }}
-          restore-keys: |
-            ${{ runner.os }}-vagrant-
-
-      - name: setup Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: '1.19'
-
-      - name: 'test (debian6, 1.19)'
-        id:   'debian6'
-        run: |
-          cp -f .github/workflows/Vagrantfile.debian6 Vagrantfile
-          export GOOS=linux
-          export GOARCH=amd64
-          for p in $(go list ./...); do
-            FSNOTIFY_BUFFER=4096 go test -c -o ${p//\//-}.test $p
-                                 go test -c -o ${p//\//-}.test $p
-          done
-          vagrant up
-          for t in *.test; do
-            FSNOTIFY_BUFFER=4096 vagrant ssh -c "/vagrant/$t -test.parallel 1"
-                                 vagrant ssh -c "/vagrant/$t -test.parallel 1"
-          done
+  # Solaris
+  # TODO: latest version is go 1.7(!) Need ot find a good way to install a more
+  # recent version; the go.dev doesn't have binaries for Solaris.
+  # solaris:
+  #   runs-on: 'ubuntu-latest'
+  #   name: 'test (solaris, 1.17)'
+  #   steps:
+  #   - uses: 'actions/checkout@v4'
+  #   - name: 'test (solaris, 1.17)'
+  #     id:   'solaris'
+  #     uses: 'vmactions/solaris-vm@v1'
+  #     with:
+  #       prepare: pkg install pkg://solaris/developer/golang-17
+  #       run: |
+  #         useradd action
+  #         export GOCACHE=/tmp/go-cache
+  #         export GOPATH=/tmp/go-path
+  #         FSNOTIFY_BUFFER=4096 su action -c 'go test -parallel 1 ./...'
+  #                              su action -c 'go test -parallel 1 ./...'


### PR DESCRIPTION
Use the new vmactions runners based on linux/qemu rather than
macos/vagrant. This should be much more stable and reliable.

Also switch the illumos VM to that, since they now have one, and add
DragonFlyBSD.

Remove the old Debian 6 test. It's broken and not all that useful to
have; maybe some systems want to use current versions of fsnotify on
very old Linux kernels, but I doubt it.