### PR TITLE
kqueue: set O_CLOEXEC on close pipe fds

### DIFF
--- a/backend_kqueue.go
+++ b/backend_kqueue.go
@@ -198,6 +198,8 @@ func newKqueue() (kq int, closepipe [2]int, err error) {
 		unix.Close(kq)
 		return kq, closepipe, err
 	}
+	unix.CloseOnExec(closepipe[0])
+	unix.CloseOnExec(closepipe[1])
 
 	// Register changes to listen on the closepipe.
 	changes := make([]unix.Kevent_t, 1)


### PR DESCRIPTION
These file descriptors are being leaked to child processes because O_CLOEXEC isn't set.