### PR TITLE
Fix CI on NetBSD

### DIFF
--- a/fsnotify_test.go
+++ b/fsnotify_test.go
@@ -285,10 +285,8 @@ func TestWatchWrite(t *testing.T) {
 			write  /file  # truncate
 			write  /file  # write
 
-			# Truncate is chmod on kqueue, except NetBSD where it's ignored, and
-			# on dragonfly it seems a write.
-			netbsd:
-				write  /file
+			# Truncate is chmod on kqueue, except dragonfly where it seems a
+			# write.
 			dragonfly:
 				write  /file
 				write  /file


### PR DESCRIPTION
Seems to work now(?) This exception has been there for years, but now it consistently seems to fail both for me locally and in the CI (for example in #617). But on the main branch it worked just a few weeks ago(?)

And while the CI could have been updated, my local environment hasn't:

	netbsd$ uname -a
	NetBSD 9.2 (GENERIC) #0: Wed May 12 13:15:55 UTC 2021  mkrepro@mkrepro.NetBSD.org:/usr/src/sys/arch/amd64/compile/GENERIC

🤷