### PR TITLE
fen: allow watching subdirectories of watched directories

### DIFF
--- a/backend_fen.go
+++ b/backend_fen.go
@@ -1,6 +1,10 @@
 //go:build solaris
 // +build solaris
 
+// FEN backend for illumos (supported) and Solaris (untested, but should work).
+//
+// See port_create(3c) etc. for docs. https://www.illumos.org/man/3C/port_create
+//
 // Note: the documentation on the Watcher type and methods is generated from
 // mkdoc.zsh
 
@@ -257,9 +261,6 @@ func (w *Watcher) Add(name string) error { return w.AddWith(name) }
 func (w *Watcher) AddWith(name string, opts ...addOpt) error {
 	if w.isClosed() {
 		return ErrClosed
-	}
-	if w.port.PathIsWatched(name) {
-		return nil
 	}
 	if debug {
 		fmt.Fprintf(os.Stderr, "FSNOTIFY_DEBUG: %s  AddWith(%q)\n",

--- a/fsnotify_test.go
+++ b/fsnotify_test.go
@@ -160,6 +160,44 @@ func TestWatch(t *testing.T) {
 		}, `
 			write    /file
 		`},
+
+		{"watch subdir", func(t *testing.T, w *Watcher, tmp string) {
+			// This consistently works fine on my NetBSD 9.2/Go 1.17 machine,
+			// but not with NetBSD 10.0/Go 1.21 in the CI. I don't know if it's
+			// the version or something else – need to look into that.
+			//
+			// Fails with:
+			//
+			//   CREATE               "/dir"
+			//   CREATE               "/one"
+			//   WRITE                "/one"
+			//   REMOVE               "/one"
+			if runtime.GOOS == "netbsd" && isCI() {
+				t.Skip("fails in CI") // TODO
+			}
+			dir := join(tmp, "dir")
+
+			addWatch(t, w, tmp)
+			mkdir(t, dir)
+			addWatch(t, w, dir)
+
+			cat(t, "hello", tmp, "one")
+			cat(t, "hello", dir, "two")
+
+			rm(t, tmp, "one")
+			rm(t, dir, "two")
+		}, `
+			create   /dir
+
+			create   /one
+			write    /one
+
+			create   /dir/two
+			write    /dir/two
+
+			remove   /one
+			remove   /dir/two
+		`},
 	}
 
 	for _, tt := range tests {
@@ -750,10 +788,6 @@ func TestWatchRemove(t *testing.T) {
 			# TODO: no remove events?
 			dragonfly:
 				create    /abc
-			# TODO: no event for /abc/def?
-			fen:
-				create    /abc
-				remove    /abc
 		`},
 	}
 


### PR DESCRIPTION
When watching /tmp, w.port.PathIsWatched(name) returned true for /tmp/abc. PathIsWatched() checks:

	_, found := e.paths[path]
	return found

That e.paths gets set in EventPort.AssociatePath(), which is called by Watcher.associateFile() for every path inside a watched directory. So it can never watch subpaths.

Anyway, this seems safe to remove. Could check our own Watcher.dirs state, but this doesn't seem needed (we already have tests for watching the same path more than once).

(This came rolling out of #620).