### PR TITLE
kqueue: fix watching relative symlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 # Output of go build ./cmd/fsnotify
 /fsnotify
 /fsnotify.exe
+
+/test/kqueue
+/test/a.out

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,19 @@ Unreleased
 
 - kqueue: set O_CLOEXEC to prevent passing file descriptors to children ([#617])
 
+- kqueue: relative symlinks didn't work (e.g. `link -> dir`, rather than `/tmp/dir`) ([#622])
+
 - inotify: don't send event for IN_DELETE_SELF when also watching the parent ([#620])
+
+- fen: allow watching subdirectories of watched directories ([#621])
 
 [#590]: https://github.com/fsnotify/fsnotify/pull/590
 [#610]: https://github.com/fsnotify/fsnotify/pull/610
 [#617]: https://github.com/fsnotify/fsnotify/pull/617
 [#619]: https://github.com/fsnotify/fsnotify/pull/619
 [#620]: https://github.com/fsnotify/fsnotify/pull/620
+[#621]: https://github.com/fsnotify/fsnotify/pull/621
+[#622]: https://github.com/fsnotify/fsnotify/pull/622
 
 1.7.0 - 2023-10-22
 ------------------

--- a/backend_kqueue.go
+++ b/backend_kqueue.go
@@ -453,7 +453,7 @@ func (w *Watcher) addWatch(name string, flags uint32) (string, error) {
 
 		// Follow Symlinks.
 		if fi.Mode()&os.ModeSymlink == os.ModeSymlink {
-			link, err := os.Readlink(name)
+			link, err := filepath.EvalSymlinks(name)
 			if err != nil {
 				// Return nil because Linux can add unresolvable symlinks to the
 				// watch list without problems, so maintain consistency with

--- a/testdata/watch-symlink/to-dir-relative
+++ b/testdata/watch-symlink/to-dir-relative
@@ -1,0 +1,15 @@
+# Watch a symlink to a dir
+require symlink
+
+mkdir /dir
+ln -s ./dir /link
+watch /link
+
+touch /dir/file
+
+Output:
+	create    /link/file
+
+	kqueue:  # TODO: Should use the link name.
+		create /dir/file
+

--- a/testdata/watch-symlink/to-file-relative
+++ b/testdata/watch-symlink/to-file-relative
@@ -2,7 +2,7 @@
 require symlink
 
 touch /file
-ln -s /file /link
+ln -s ./file /link
 watch /link
 
 echo hello >>/file


### PR DESCRIPTION
os.Readlink() just returns the value of the link.