### PR TITLE
kqueue: emit events as "/path/dir/file" instead of "path/link/file"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Unreleased
 
 - kqueue: set O_CLOEXEC to prevent passing file descriptors to children ([#617])
 
+- kqueue: emit events as "/path/dir/file" instead of "path/link/file" when watching a symlink ([#625])
+
 - inotify: don't send event for IN_DELETE_SELF when also watching the parent ([#620])
 
 - fen: allow watching subdirectories of watched directories ([#621])
@@ -25,6 +27,7 @@ Unreleased
 [#619]: https://github.com/fsnotify/fsnotify/pull/619
 [#620]: https://github.com/fsnotify/fsnotify/pull/620
 [#621]: https://github.com/fsnotify/fsnotify/pull/621
+[#625]: https://github.com/fsnotify/fsnotify/pull/625
 
 1.7.0 - 2023-10-22
 ------------------

--- a/testdata/watch-symlink/to-dir
+++ b/testdata/watch-symlink/to-dir
@@ -9,6 +9,3 @@ touch /dir/file
 
 Output:
 	create    /link/file
-
-	kqueue:  # TODO: Should use the link name.
-		create /dir/file

--- a/testdata/watch-symlink/to-file
+++ b/testdata/watch-symlink/to-file
@@ -10,7 +10,5 @@ echo hello >>/file
 Output:
 	write    /link
 
-	kqueue:   # TODO: Should use the link name.
-		write    /file
 	windows: # TODO: investigate.
 		no-events


### PR DESCRIPTION
When watching a symlink to a directory it would emit events with the target name, rather than the link name.