### PR TITLE
Print unknown flags with FSNOTIFY_DEBUG

### DIFF
--- a/internal/debug_kqueue.go
+++ b/internal/debug_kqueue.go
@@ -13,11 +13,19 @@ import (
 
 func Debug(name string, kevent *unix.Kevent_t) {
 	mask := uint32(kevent.Fflags)
-	var l []string
+
+	var (
+		l       []string
+		unknown = mask
+	)
 	for _, n := range names {
 		if mask&n.m == n.m {
 			l = append(l, n.n)
+			unknown ^= n.m
 		}
+	}
+	if unknown > 0 {
+		l = append(l, fmt.Sprintf("0x%x", unknown))
 	}
 	fmt.Fprintf(os.Stderr, "FSNOTIFY_DEBUG: %s  %10d:%-60s → %q\n",
 		time.Now().Format("15:04:05.000000000"), mask, strings.Join(l, " | "), name)

--- a/internal/debug_linux.go
+++ b/internal/debug_linux.go
@@ -53,11 +53,18 @@ func Debug(name string, mask uint32) {
 		{"IN_UNMOUNT", unix.IN_UNMOUNT},
 	}
 
-	var l []string
+	var (
+		l       []string
+		unknown = mask
+	)
 	for _, n := range names {
 		if mask&n.m == n.m {
 			l = append(l, n.n)
+			unknown ^= n.m
 		}
+	}
+	if unknown > 0 {
+		l = append(l, fmt.Sprintf("0x%x", unknown))
 	}
 	fmt.Fprintf(os.Stderr, "FSNOTIFY_DEBUG: %s  %10d:%-30s → %q\n",
 		time.Now().Format("15:04:05.000000000"), mask, strings.Join(l, " | "), name)

--- a/internal/debug_solaris.go
+++ b/internal/debug_solaris.go
@@ -27,11 +27,18 @@ func Debug(name string, mask int32) {
 		{"FILE_EXCEPTION", unix.FILE_EXCEPTION},
 	}
 
-	var l []string
+	var (
+		l       []string
+		unknown = mask
+	)
 	for _, n := range names {
 		if mask&n.m == n.m {
 			l = append(l, n.n)
+			unknown ^= n.m
 		}
+	}
+	if unknown > 0 {
+		l = append(l, fmt.Sprintf("0x%x", unknown))
 	}
 	fmt.Fprintf(os.Stderr, "FSNOTIFY_DEBUG: %s  %10d:%-30s → %q\n",
 		time.Now().Format("15:04:05.000000000"), mask, strings.Join(l, " | "), name)

--- a/internal/debug_windows.go
+++ b/internal/debug_windows.go
@@ -29,11 +29,18 @@ func Debug(name string, mask uint32) {
 		{"FILE_ACTION_RENAMED_NEW_NAME", windows.FILE_ACTION_RENAMED_NEW_NAME},
 	}
 
-	var l []string
+	var (
+		l       []string
+		unknown = mask
+	)
 	for _, n := range names {
 		if mask&n.m == n.m {
 			l = append(l, n.n)
+			unknown ^= n.m
 		}
+	}
+	if unknown > 0 {
+		l = append(l, fmt.Sprintf("0x%x", unknown))
 	}
 	fmt.Fprintf(os.Stderr, "FSNOTIFY_DEBUG: %s  %2d:%-65s → %q\n",
 		time.Now().Format("15:04:05.000000000"), mask, strings.Join(l, " | "), name)


### PR DESCRIPTION
The only way we can convert a mask to something with meaningful names is by keeping a static list. That's fine, but flags we don't know would get silently dropped.