### PR TITLE
inotify, windows: track renames

### DIFF
--- a/fsnotify.go
+++ b/fsnotify.go
@@ -46,6 +46,16 @@ type Event struct {
 	// This is a bitmask and some systems may send multiple operations at once.
 	// Use the Event.Has() method instead of comparing with ==.
 	Op Op
+
+	// Create events will have this set to the old path if it's a rename. This
+	// only works when both the source and destination are watched. It's not
+	// reliable when watching individual files, only directories.
+	//
+	// For example "mv /tmp/file /tmp/rename" will emit:
+	//
+	//   Event{Op: Rename, Name: "/tmp/file"}
+	//   Event{Op: Create, Name: "/tmp/rename", RenamedFrom: "/tmp/file"}
+	renamedFrom string
 }
 
 // Op describes a set of file operations.
@@ -128,6 +138,9 @@ func (e Event) Has(op Op) bool { return e.Op.Has(op) }
 
 // String returns a string representation of the event with their path.
 func (e Event) String() string {
+	if e.renamedFrom != "" {
+		return fmt.Sprintf("%-13s %q ← %q", e.Op.String(), e.Name, e.renamedFrom)
+	}
 	return fmt.Sprintf("%-13s %q", e.Op.String(), e.Name)
 }
 

--- a/fsnotify_test.go
+++ b/fsnotify_test.go
@@ -621,15 +621,15 @@ func TestEventString(t *testing.T) {
 		want string
 	}{
 		{Event{}, `[no events]   ""`},
-		{Event{"/file", 0}, `[no events]   "/file"`},
+		{Event{Name: "/file", Op: 0}, `[no events]   "/file"`},
 
-		{Event{"/file", Chmod | Create},
+		{Event{Name: "/file", Op: Chmod | Create},
 			`CREATE|CHMOD  "/file"`},
-		{Event{"/file", Rename},
+		{Event{Name: "/file", Op: Rename},
 			`RENAME        "/file"`},
-		{Event{"/file", Remove},
+		{Event{Name: "/file", Op: Remove},
 			`REMOVE        "/file"`},
-		{Event{"/file", Write | Chmod},
+		{Event{Name: "/file", Op: Write | Chmod},
 			`WRITE|CHMOD   "/file"`},
 	}
 

--- a/internal/debug_linux.go
+++ b/internal/debug_linux.go
@@ -9,45 +9,26 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func Debug(name string, mask uint32) {
+func Debug(name string, mask, cookie uint32) {
 	names := []struct {
 		n string
 		m uint32
 	}{
 		{"IN_ACCESS", unix.IN_ACCESS},
-		{"IN_ALL_EVENTS", unix.IN_ALL_EVENTS},
 		{"IN_ATTRIB", unix.IN_ATTRIB},
-		{"IN_CLASSA_HOST", unix.IN_CLASSA_HOST},
-		{"IN_CLASSA_MAX", unix.IN_CLASSA_MAX},
-		{"IN_CLASSA_NET", unix.IN_CLASSA_NET},
-		{"IN_CLASSA_NSHIFT", unix.IN_CLASSA_NSHIFT},
-		{"IN_CLASSB_HOST", unix.IN_CLASSB_HOST},
-		{"IN_CLASSB_MAX", unix.IN_CLASSB_MAX},
-		{"IN_CLASSB_NET", unix.IN_CLASSB_NET},
-		{"IN_CLASSB_NSHIFT", unix.IN_CLASSB_NSHIFT},
-		{"IN_CLASSC_HOST", unix.IN_CLASSC_HOST},
-		{"IN_CLASSC_NET", unix.IN_CLASSC_NET},
-		{"IN_CLASSC_NSHIFT", unix.IN_CLASSC_NSHIFT},
 		{"IN_CLOSE", unix.IN_CLOSE},
 		{"IN_CLOSE_NOWRITE", unix.IN_CLOSE_NOWRITE},
 		{"IN_CLOSE_WRITE", unix.IN_CLOSE_WRITE},
 		{"IN_CREATE", unix.IN_CREATE},
 		{"IN_DELETE", unix.IN_DELETE},
 		{"IN_DELETE_SELF", unix.IN_DELETE_SELF},
-		{"IN_DONT_FOLLOW", unix.IN_DONT_FOLLOW},
-		{"IN_EXCL_UNLINK", unix.IN_EXCL_UNLINK},
 		{"IN_IGNORED", unix.IN_IGNORED},
 		{"IN_ISDIR", unix.IN_ISDIR},
-		{"IN_LOOPBACKNET", unix.IN_LOOPBACKNET},
-		{"IN_MASK_ADD", unix.IN_MASK_ADD},
-		{"IN_MASK_CREATE", unix.IN_MASK_CREATE},
 		{"IN_MODIFY", unix.IN_MODIFY},
 		{"IN_MOVE", unix.IN_MOVE},
 		{"IN_MOVED_FROM", unix.IN_MOVED_FROM},
 		{"IN_MOVED_TO", unix.IN_MOVED_TO},
 		{"IN_MOVE_SELF", unix.IN_MOVE_SELF},
-		{"IN_ONESHOT", unix.IN_ONESHOT},
-		{"IN_ONLYDIR", unix.IN_ONLYDIR},
 		{"IN_OPEN", unix.IN_OPEN},
 		{"IN_Q_OVERFLOW", unix.IN_Q_OVERFLOW},
 		{"IN_UNMOUNT", unix.IN_UNMOUNT},
@@ -66,6 +47,10 @@ func Debug(name string, mask uint32) {
 	if unknown > 0 {
 		l = append(l, fmt.Sprintf("0x%x", unknown))
 	}
-	fmt.Fprintf(os.Stderr, "FSNOTIFY_DEBUG: %s  %10d:%-30s → %q\n",
-		time.Now().Format("15:04:05.000000000"), mask, strings.Join(l, " | "), name)
+	var c string
+	if cookie > 0 {
+		c = fmt.Sprintf("(cookie: %d) ", cookie)
+	}
+	fmt.Fprintf(os.Stderr, "FSNOTIFY_DEBUG: %s  %-30s → %s%q\n",
+		time.Now().Format("15:04:05.000000000"), strings.Join(l, "|"), c, name)
 }

--- a/internal/debug_windows.go
+++ b/internal/debug_windows.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -14,14 +15,6 @@ func Debug(name string, mask uint32) {
 		n string
 		m uint32
 	}{
-		//{"FILE_NOTIFY_CHANGE_FILE_NAME", windows.FILE_NOTIFY_CHANGE_FILE_NAME},
-		//{"FILE_NOTIFY_CHANGE_DIR_NAME", windows.FILE_NOTIFY_CHANGE_DIR_NAME},
-		//{"FILE_NOTIFY_CHANGE_ATTRIBUTES", windows.FILE_NOTIFY_CHANGE_ATTRIBUTES},
-		//{"FILE_NOTIFY_CHANGE_SIZE", windows.FILE_NOTIFY_CHANGE_SIZE},
-		//{"FILE_NOTIFY_CHANGE_LAST_WRITE", windows.FILE_NOTIFY_CHANGE_LAST_WRITE},
-		//{"FILE_NOTIFY_CHANGE_LAST_ACCESS", windows.FILE_NOTIFY_CHANGE_LAST_ACCESS},
-		//{"FILE_NOTIFY_CHANGE_CREATION", windows.FILE_NOTIFY_CHANGE_CREATION},
-		//{"FILE_NOTIFY_CHANGE_SECURITY", windows.FILE_NOTIFY_CHANGE_SECURITY},
 		{"FILE_ACTION_ADDED", windows.FILE_ACTION_ADDED},
 		{"FILE_ACTION_REMOVED", windows.FILE_ACTION_REMOVED},
 		{"FILE_ACTION_MODIFIED", windows.FILE_ACTION_MODIFIED},
@@ -42,6 +35,6 @@ func Debug(name string, mask uint32) {
 	if unknown > 0 {
 		l = append(l, fmt.Sprintf("0x%x", unknown))
 	}
-	fmt.Fprintf(os.Stderr, "FSNOTIFY_DEBUG: %s  %2d:%-65s → %q\n",
-		time.Now().Format("15:04:05.000000000"), mask, strings.Join(l, " | "), name)
+	fmt.Fprintf(os.Stderr, "FSNOTIFY_DEBUG: %s  %-65s → %q\n",
+		time.Now().Format("15:04:05.000000000"), strings.Join(l, " | "), filepath.ToSlash(name))
 }

--- a/testdata/watch-dir/bug-277
+++ b/testdata/watch-dir/bug-277
@@ -15,12 +15,12 @@ mv     /apple /pear
 rm -r  /pear
 
 Output:
-	create   /foo     # touch foo
-	remove   /foo     # rm foo
-	create   /apple   # mkdir apple
-	rename   /apple   # mv apple pear
-	create   /pear
-	remove   /pear    # rm -r pear
+	create   /foo     # touch /foo
+	remove   /foo     # rm /foo
+	create   /apple   # mkdir /apple
+	rename   /apple   # mv /apple /pear
+	create   /pear ← /apple
+	remove   /pear    # rm -r /pear
 
 	dragonfly:
 		create   /foo

--- a/testdata/watch-dir/rename-file
+++ b/testdata/watch-dir/rename-file
@@ -2,8 +2,8 @@
 
 echo asd >>/file
 watch /
-mv /file /renamed
+mv /file /rename
 
 Output:
 	rename /file
-	create /renamed
+	create /rename ← /file

--- a/testdata/watch-dir/rename-from-other-watch
+++ b/testdata/watch-dir/rename-from-other-watch
@@ -1,0 +1,22 @@
+# Rename from one watched directory to another watched directory.
+
+mkdir /dir1
+mkdir /dir2
+touch /dir1/file
+
+watch /dir1
+watch /dir2
+
+mv /dir1/file /dir2/rename
+
+Output:
+	rename /dir1/file
+	create /dir2/rename ← /dir1/file
+
+	# Windows just doesn't send anything for this; seems like all watches are
+	# independent.
+	#
+	# TODO: consider emulating this behaviour on other platforms.
+	windows:
+		remove /dir1/file
+		create /dir2/rename

--- a/testdata/watch-dir/rename-from-unwatched-overwrite
+++ b/testdata/watch-dir/rename-from-unwatched-overwrite
@@ -10,7 +10,6 @@ watch /dir
 mv /unwatch/file /dir/rename
 
 Output:
-	# TODO: this should really be RENAME.
 	remove /dir/rename
 	create /dir/rename
 

--- a/testdata/watch-dir/rename-overwrite
+++ b/testdata/watch-dir/rename-overwrite
@@ -1,0 +1,22 @@
+# Rename file in watched dir, overwriting an existing file.
+
+touch /file
+touch /rename
+
+watch /
+
+mv /file /rename
+
+Output:
+	remove  /rename
+	rename  /file
+	create  /rename ← /file
+
+	# Inotify just sends MOVED_FROM and MOVED_TO.
+	linux:
+		rename /file
+		create /rename ← /file
+
+	dragonfly:
+		remove /
+		rename /file

--- a/testdata/watch-dir/rename-symlink
+++ b/testdata/watch-dir/rename-symlink
@@ -10,7 +10,7 @@ mv /link /link-rename
 
 Output:
 	rename /link
-	create /link-rename
+	create /link-rename ← /link
 
 	kqueue:  # TODO: this is broken.
 		create /link-rename

--- a/testdata/watch-file/overwrite-watched-file
+++ b/testdata/watch-file/overwrite-watched-file
@@ -1,0 +1,29 @@
+# Overwrite watched file with non-watched file.
+
+touch /file
+touch /unwatch
+
+watch /file
+
+mv /unwatch /file
+
+echo asd >>/file
+rm /file
+
+# TODO: think what the best behaviour is here; do we want to keep the watch or
+# lose it? It's inconsistent now.
+Output:
+	remove   /file
+
+	linux:
+		chmod    /file
+		remove   /file
+
+	kqueue:
+		remove   /file
+		create   /file
+		write    /file
+		remove   /file
+
+	dragonfly:
+		no-events

--- a/testdata/watch-file/overwrite-watched-file-with-watched-file
+++ b/testdata/watch-file/overwrite-watched-file-with-watched-file
@@ -1,0 +1,41 @@
+# Overwrite watched file with non-watched file.
+
+touch /file
+touch /other
+
+watch /file
+watch /other
+
+mv /other /file
+
+echo asd >>/file
+rm /file
+
+# TODO: think what the best behaviour is here; do we want to keep the watch or
+# lose it? It's inconsistent now.
+Output:
+	# On inotify we just get IN_MOVE_SELF and IN_DELETE_SELF without cookie; no
+	# way to track this.
+	chmod    /file
+	rename   /other
+	remove   /file
+
+	kqueue:
+		rename   /other
+		remove   /file
+		create   /file
+		write    /file
+		remove   /file
+
+	windows:
+		remove   /file
+		rename   /other
+		write    /file
+		remove   /file
+
+	fen:
+		remove   /file
+		rename   /other
+
+	dragonfly:
+		rename /other

--- a/testdata/watch-recurse/rename-dir
+++ b/testdata/watch-recurse/rename-dir
@@ -10,7 +10,7 @@ touch /sub-rename/dir/file
 
 Output:
 	rename     /sub                  # mv /sub /sub-rename
-	create     /sub-rename
+	create     /sub-rename ← /sub
 
 	write      /sub-rename           # touch /sub-rename/file
 	create     /sub-rename/file


### PR DESCRIPTION
Add Event.RenamedFrom to track event renames; this is sent on a subsequent Create event; for example:

	Event{Op: Rename, Name: "/tmp/file"}
	Event{Op: Create, Name: "/tmp/renamed", RenamedFrom: "/tmp/file"}

For now this is unexported as renamedFrom because the kqueue and FEN backends are not yet implemented.

Updates #26