### PR TITLE
fix: accident nil pointer error when removing watch descriptor without map value checking in watches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 
 /test/kqueue
 /test/a.out
+
+# ignore ide files from idea
+.idea/

--- a/backend_inotify.go
+++ b/backend_inotify.go
@@ -14,8 +14,9 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/fsnotify/fsnotify/internal"
 	"golang.org/x/sys/unix"
+
+	"github.com/fsnotify/fsnotify/internal"
 )
 
 type inotify struct {
@@ -91,8 +92,10 @@ func (w *watches) add(ww *watch) {
 func (w *watches) remove(wd uint32) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	delete(w.path, w.wd[wd].path)
-	delete(w.wd, wd)
+	if v, ok := w.wd[wd]; ok {
+		delete(w.path, v.path)
+		delete(w.wd, wd)
+	}
 }
 
 func (w *watches) removePath(path string) ([]uint32, error) {


### PR DESCRIPTION
We've got a nil pointer issue that caused by fsnotify v1.7.0, but it still exists in latest codes, so I post this pr to add additional existence check for value of watch descriptors map.
