### PR TITLE
Update CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   # linux/arm64
   linux-arm64:
     machine:
-      image: ubuntu-2204:2022.07.1
+      image: ubuntu-2204:2024.05.1
     resource_class: arm.medium
     working_directory: ~/repo
     steps:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
 freebsd_task:
   name: 'FreeBSD'
   freebsd_instance:
-    image_family: freebsd-13-2
+    image_family: freebsd-14-1
   install_script:
     - pkg update -f
     - pkg install -y go

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.17', '1.22']
+        go: ['1.17', '1.23']
     runs-on: 'ubuntu-latest'
     steps:
       - uses: 'actions/checkout@v4'

--- a/.github/workflows/staticcheck.yml
+++ b/.github/workflows/staticcheck.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: 'actions/setup-go@v5'
         with:
-          go-version: '1.22'
+          go-version: '1.23'
 
       - uses: 'actions/cache@v4'
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-20.04', 'ubuntu-latest']
-        go: ['1.17', '1.22']
+        go: ['1.17', '1.23']
     runs-on: '${{ matrix.os }}'
     steps:
       - uses: 'actions/checkout@v4'
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['windows-latest']
-        go: ['1.17', '1.22']
+        go: ['1.17', '1.23']
     runs-on: '${{ matrix.os }}'
     steps:
       - uses: 'actions/checkout@v4'
@@ -69,13 +69,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['macos-11', 'macos-latest']
+        os: ['macos-12', 'macos-latest']
     runs-on: '${{ matrix.os }}'
     steps:
       - uses: 'actions/checkout@v4'
       - uses: 'actions/setup-go@v5'
         with:
-          go-version: '1.22'
+          go-version: '1.23'
       - name: test
         run: |
           FSNOTIFY_BUFFER=4096 go test -parallel 1 -race    ./...

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 Thank you for your interest in contributing to fsnotify! We try to review and
 merge PRs in a reasonable timeframe, but please be aware that:
 
-- To avoid "wasted" work, please discus changes on the issue tracker first. You
+- To avoid "wasted" work, please discuss changes on the issue tracker first. You
   can just send PRs, but they may end up being rejected for one reason or the
   other.
 


### PR DESCRIPTION
Cirrus and CirleCI didn't work at all because the images were outdated.

Also update to Go 1.23 while I'm here.