### PR TITLE
inotify: fix potential data races on IN_DELETE_SELF event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+Unreleased
+----------
+
+### Changes and fixes
+
+- inotify: fix potential data races on IN_DELETE_SELF event ([#653])
+
+[#653]: https://github.com/fsnotify/fsnotify/pull/653
+
 1.8.0 2023-10-31
 ----------------
 

--- a/backend_inotify.go
+++ b/backend_inotify.go
@@ -531,7 +531,11 @@ func (w *inotify) readEvents() {
 			/// Skip if we're watching both this path and the parent; the parent
 			/// will already send a delete so no need to do it twice.
 			if mask&unix.IN_DELETE_SELF != 0 {
-				if _, ok := w.watches.path[filepath.Dir(watch.path)]; ok {
+				w.watches.mu.RLock()
+				_, ok := w.watches.path[filepath.Dir(watch.path)]
+				w.watches.mu.RUnlock()
+
+				if ok {
 					next()
 					continue
 				}

--- a/backend_inotify.go
+++ b/backend_inotify.go
@@ -88,15 +88,15 @@ func (w *watches) add(ww *watch) {
 	w.path[ww.path] = ww.wd
 }
 
-func (w *watches) remove(wd uint32) {
+func (w *watches) remove(ww *watch) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
-	watch := w.wd[wd] // Could have had Remove() called. See #616.
+	watch := w.wd[ww.wd] // Could have had Remove() called. See #616.
 	if watch == nil {
 		return
 	}
 	delete(w.path, watch.path)
-	delete(w.wd, wd)
+	delete(w.wd, ww.wd)
 }
 
 func (w *watches) removePath(path string) ([]uint32, error) {
@@ -508,7 +508,7 @@ func (w *inotify) readEvents() {
 			// inotify will automatically remove the watch on deletes; just need
 			// to clean our state here.
 			if mask&unix.IN_DELETE_SELF == unix.IN_DELETE_SELF {
-				w.watches.remove(watch.wd)
+				w.watches.remove(watch)
 			}
 
 			// We can't really update the state when a watched path is moved;


### PR DESCRIPTION
The blamed commit introduced a check to prevent sending a delete event in case the parent is being watched as well. However, it accesses the `watches.path` map without synchronization, possibly leading to a data race in case the same map is accessed in parallel (e.g., by an `Add()` operation). Let's fix this by grabbing the associated lock before reading from the map.

Excerpt of the data race trace:

```
Write at 0x00c0004d8cf0 by goroutine 33:
  runtime.mapassign_faststr()
      golang.org/toolchain@v0.0.1-go1.23.0.linux-amd64/src/runtime/map_faststr.go:223 +0x0
  github.com/fsnotify/fsnotify.(*watches).updatePath()
      github.com/fsnotify/fsnotify/backend_inotify.go:163 +0x2b8
  github.com/fsnotify/fsnotify.(*inotify).register()
      github.com/fsnotify/fsnotify/backend_inotify.go:335 +0x1bd
  github.com/fsnotify/fsnotify.(*inotify).add()
      github.com/fsnotify/fsnotify/backend_inotify.go:331 +0xee
  github.com/fsnotify/fsnotify.(*inotify).AddWith()
      github.com/fsnotify/fsnotify/backend_inotify.go:296 +0x405
  github.com/fsnotify/fsnotify.(*inotify).Add()
      github.com/fsnotify/fsnotify/backend_inotify.go:253 +0x44
  github.com/fsnotify/fsnotify.(*Watcher).Add()
      github.com/fsnotify/fsnotify/fsnotify.go:313 +0x5ce

Previous read at 0x00c0004d8cf0 by goroutine 32:
  runtime.mapaccess2_faststr()
      golang.org/toolchain@v0.0.1-go1.23.0.linux-amd64/src/runtime/map_faststr.go:117 +0x0
  github.com/fsnotify/fsnotify.(*inotify).readEvents()
      github.com/fsnotify/fsnotify/backend_inotify.go:534 +0xd04
  github.com/fsnotify/fsnotify.newBufferedBackend.gowrap1()
      github.com/fsnotify/fsnotify/backend_inotify.go:195 +0x33
```

Fixes: e75779f82599 ("inotify: don't send event for IN_DELETE_SELF when also watching the parent (#620)")

---

Additionally, the processing of IN_DELETE_SELF events is currently affected by a second possible data race in case of parallel Add() operations, because it accesses the `wd` field of the current watch without synchronization, although it may be potentially mutated in parallel after having added a new watcher. Let's fix this by making sure that the field is only accessed inside the remove function, after having grabbed the lock.
    
Excerpt of the data race trace:

```
Write at 0x00c00007e600 by goroutine 10:
  github.com/fsnotify/fsnotify.(*inotify).add.(*inotify).register.func1()
      github.com/fsnotify/other/fsnotify/backend_inotify.go:354 +0x1f4
  github.com/fsnotify/fsnotify.(*watches).updatePath()
      github.com/fsnotify/other/fsnotify/backend_inotify.go:157 +0x18c
  github.com/fsnotify/fsnotify.(*inotify).register()
      github.com/fsnotify/other/fsnotify/backend_inotify.go:335 +0x1bd
  github.com/fsnotify/fsnotify.(*inotify).add()
      github.com/fsnotify/other/fsnotify/backend_inotify.go:331 +0xee
  github.com/fsnotify/fsnotify.(*inotify).AddWith()
      github.com/fsnotify/other/fsnotify/backend_inotify.go:296 +0x405
  github.com/fsnotify/fsnotify.(*inotify).Add()
      github.com/fsnotify/other/fsnotify/backend_inotify.go:253 +0x44
  github.com/fsnotify/fsnotify.(*Watcher).Add()
      github.com/fsnotify/other/fsnotify/fsnotify.go:313 +0x146
  github.com/fsnotify/fsnotify.addWatch()
      github.com/fsnotify/other/fsnotify/helpers_test.go:73 +0xd1
  github.com/fsnotify/fsnotify.TestInDeleteSelfRace()
      github.com/fsnotify/other/fsnotify/backend_inotify_test.go:191 +0xa5b
  testing.tRunner()
      /usr/lib/go-1.22/src/testing/testing.go:1689 +0x21e
  testing.(*T).Run.gowrap1()
      /usr/lib/go-1.22/src/testing/testing.go:1742 +0x44

Previous read at 0x00c00007e600 by goroutine 11:
  github.com/fsnotify/fsnotify.(*inotify).readEvents()
      github.com/fsnotify/other/fsnotify/backend_inotify.go:511 +0xa38
  github.com/fsnotify/fsnotify.newBufferedBackend.gowrap1()
      github.com/fsnotify/other/fsnotify/backend_inotify.go:195 +0x33
```