### PR TITLE
fix(inotify): racy watches map access in readEvents

### DIFF
--- a/backend_inotify.go
+++ b/backend_inotify.go
@@ -531,7 +531,10 @@ func (w *inotify) readEvents() {
 			/// Skip if we're watching both this path and the parent; the parent
 			/// will already send a delete so no need to do it twice.
 			if mask&unix.IN_DELETE_SELF != 0 {
-				if _, ok := w.watches.path[filepath.Dir(watch.path)]; ok {
+				w.watches.mu.RLock()
+				_, ok := w.watches.path[filepath.Dir(watch.path)]
+				w.watches.mu.RUnlock()
+				if ok {
 					next()
 					continue
 				}


### PR DESCRIPTION
the go test race detector detected racy access around this map. project specific details omitted.

TLDR of the test is there were a lot of concurrent dir creations, file writes, deletions, and watch.Adds.

```
WARNING: DATA RACE
Write at 0x00c00412c870 by goroutine 6975:
  runtime.mapassign_faststr()
      /usr/local/go/src/runtime/map_faststr.go:203 +0x0
  github.com/fsnotify/fsnotify.(*watches).updatePath()
      /go/pkg/mod/github.com/fsnotify/fsnotify@v1.8.0/backend_inotify.go:163 +0x2b8
  github.com/fsnotify/fsnotify.(*inotify).register()
      /go/pkg/mod/github.com/fsnotify/fsnotify@v1.8.0/backend_inotify.go:335 +0x1bd
  github.com/fsnotify/fsnotify.(*inotify).add()
      /go/pkg/mod/github.com/fsnotify/fsnotify@v1.8.0/backend_inotify.go:331 +0xee
  github.com/fsnotify/fsnotify.(*inotify).AddWith()
      /go/pkg/mod/github.com/fsnotify/fsnotify@v1.8.0/backend_inotify.go:296 +0x405
  github.com/fsnotify/fsnotify.(*inotify).Add()
      /go/pkg/mod/github.com/fsnotify/fsnotify@v1.8.0/backend_inotify.go:253 +0x44
  github.com/fsnotify/fsnotify.(*Watcher).Add()
      /go/pkg/mod/github.com/fsnotify/fsnotify@v1.8.0/fsnotify.go:313 +0x1929
  ...

Previous read at 0x00c00412c870 by goroutine 6974:
  runtime.mapaccess2_faststr()
      /usr/local/go/src/runtime/map_faststr.go:108 +0x0
  github.com/fsnotify/fsnotify.(*inotify).readEvents()
      /go/pkg/mod/github.com/fsnotify/fsnotify@v1.8.0/backend_inotify.go:534 +0xd04
  github.com/fsnotify/fsnotify.newBufferedBackend.gowrap1()
      /go/pkg/mod/github.com/fsnotify/fsnotify@v1.8.0/backend_inotify.go:195 +0x33

Goroutine 6975 (running) created at:
  ....(*Monitor).Start()
...
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1689 +0x21e
  testing.(*T).Run.gowrap1()
      /usr/local/go/src/testing/testing.go:1742 +0x44

Goroutine 6974 (running) created at:
  github.com/fsnotify/fsnotify.newBufferedBackend()
      /go/pkg/mod/github.com/fsnotify/fsnotify@v1.8.0/backend_inotify.go:195 +0x3c6
  github.com/fsnotify/fsnotify.newBackend()
      /go/pkg/mod/github.com/fsnotify/fsnotify@v1.8.0/backend_inotify.go:174 +0x51
  github.com/fsnotify/fsnotify.NewWatcher()
      /go/pkg/mod/github.com/fsnotify/fsnotify@v1.8.0/fsnotify.go:253 +0x42
  ....(*Monitor).Start()
      ...
      /usr/local/go/src/testing/testing.go:1689 +0x21e
  testing.(*T).Run.gowrap1()
      /usr/local/go/src/testing/testing.go:1742 +0x44
```