### PR TITLE
Fix hardcoded year in test

### DIFF
--- a/internal/ztest/diff_test.go
+++ b/internal/ztest/diff_test.go
@@ -147,7 +147,7 @@ func TestDiffMatch(t *testing.T) {
 		{"Hello", "He%(ANY)", ""},
 
 		{"Hello " + year + "!", "Hello %(YEAR)!", ""},
-		{"Hello " + year + "!", "Hello %(YEAR)", "\n--- have\n+++ want\n@@ -1 +1 @@\n-have Hello 2024!\n+want Hello 2024\n"},
+		{"Hello " + year + "!", "Hello %(YEAR)", "\n--- have\n+++ want\n@@ -1 +1 @@\n-have Hello " + year + "!\n+want Hello " + year + "\n"},
 
 		{"Hello xy", "Hello %(ANY 2)", ""},
 		{"Hello xy", "Hello %(ANY 2,)", ""},


### PR DESCRIPTION
A tiny fix: the year 2024 is hard-coded in one of the tests, so that it fails in The Year of the Linux Desktop.