### PR TITLE
Add recursive backend that wraps any other non-recursive backend.

### DIFF
--- a/backend_fen_test.go
+++ b/backend_fen_test.go
@@ -23,21 +23,21 @@ func TestRemoveState(t *testing.T) {
 
 	check := func(wantDirs, wantFiles int) {
 		t.Helper()
-		if len(w.b.(*fen).watches) != wantFiles {
+		if len(w.b.(*recursive).b.(*fen).watches) != wantFiles {
 			var d []string
-			for k, v := range w.b.(*fen).watches {
+			for k, v := range w.b.(*recursive).b.(*fen).watches {
 				d = append(d, fmt.Sprintf("%#v = %#v", k, v))
 			}
 			t.Errorf("unexpected number of entries in w.watches (have %d, want %d):\n%v",
-				len(w.b.(*fen).watches), wantFiles, strings.Join(d, "\n"))
+				len(w.b.(*recursive).b.(*fen).watches), wantFiles, strings.Join(d, "\n"))
 		}
-		if len(w.b.(*fen).dirs) != wantDirs {
+		if len(w.b.(*recursive).b.(*fen).dirs) != wantDirs {
 			var d []string
-			for k, v := range w.b.(*fen).dirs {
+			for k, v := range w.b.(*recursive).b.(*fen).dirs {
 				d = append(d, fmt.Sprintf("%#v = %#v", k, v))
 			}
 			t.Errorf("unexpected number of entries in w.dirs (have %d, want %d):\n%v",
-				len(w.b.(*fen).dirs), wantDirs, strings.Join(d, "\n"))
+				len(w.b.(*recursive).b.(*fen).dirs), wantDirs, strings.Join(d, "\n"))
 		}
 	}
 

--- a/backend_inotify_test.go
+++ b/backend_inotify_test.go
@@ -27,8 +27,8 @@ func TestRemoveState(t *testing.T) {
 
 	check := func(want int) {
 		t.Helper()
-		if w.b.(*inotify).watches.len() != want {
-			t.Error(w.b.(*inotify).watches)
+		if w.b.(*recursive).b.(*inotify).watches.len() != want {
+			t.Error(w.b.(*recursive).b.(*inotify).watches)
 		}
 	}
 

--- a/backend_kqueue_test.go
+++ b/backend_kqueue_test.go
@@ -18,7 +18,7 @@ func TestRemoveState(t *testing.T) {
 	touch(t, file)
 
 	w := newWatcher(t, tmp)
-	kq := w.b.(*kqueue)
+	kq := w.b.(*recursive).b.(*kqueue)
 	addWatch(t, w, tmp)
 	addWatch(t, w, file)
 

--- a/backend_recursive.go
+++ b/backend_recursive.go
@@ -1,0 +1,260 @@
+package fsnotify
+
+import (
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+)
+
+type recursive struct {
+	b         backend
+	paths     map[string]withOpts
+	pathsMu   sync.Mutex
+	ev        chan Event
+	errs      chan error
+	ev_base   chan Event
+	errs_base chan error
+	done      chan struct{}
+	doneMu    sync.Mutex
+	doneResp  chan struct{}
+}
+
+func newRecursiveBackend(ev chan Event, errs chan error) (backend, error) {
+	return newRecursiveBufferedBackend(0, ev, errs)
+}
+
+func newRecursiveBufferedBackend(sz uint, ev chan Event, errs chan error) (backend, error) {
+	// Make base backend
+	ev_base := make(chan Event)
+	errs_base := make(chan error)
+	b, err := newBufferedBackend(sz, ev_base, errs_base)
+	if err != nil {
+		return nil, err
+	}
+
+	// Wrap base backend in recursive backend
+	w := &recursive{
+		b:            b,
+		paths:        make(map[string]withOpts),
+		ev:           ev,
+		errs:         errs,
+		ev_base:   ev_base,
+		errs_base: errs_base,
+		done:         make(chan struct{}),
+		doneResp:     make(chan struct{}),
+	}
+
+	// Pipe base events through the recursive backend
+	go w.pipeEvents()
+
+	return w, nil
+}
+
+func (w *recursive) getOptions(path string) (withOpts, error) {
+	w.pathsMu.Lock()
+	defer w.pathsMu.Unlock()
+	for prefix, with := range w.paths {
+		if strings.HasPrefix(path, prefix) {
+			return with, nil
+		}
+	}
+	return defaultOpts, fmt.Errorf("%w: %s", ErrNonExistentWatch, path)
+}
+
+func (w *recursive) pipeEvents() {
+	defer func() {
+		close(w.doneResp)
+		close(w.errs)
+		close(w.ev)
+	}()
+
+	for {
+		select {
+		case <-w.done:
+			return
+		case evt, ok := <-w.ev_base:
+			if !ok {
+				return
+			}
+			w.sendEvent(evt)
+
+			if evt.Has(Create) {
+				// Establish recursive watch and, if requested, send create events
+				// for all children
+				with, err := w.getOptions(evt.Name)
+				if err == nil && with.recurse {
+					first := true
+					filepath.WalkDir(evt.Name, func(path string, d fs.DirEntry, err error) error {
+						if err != nil {
+							return err
+						}
+						if d.IsDir() && runtime.GOOS != "windows" {
+							return w.b.Add(path)
+
+							// Ideally the options would be passed but no such function exists
+							// at present
+							//return w.b.AddWith(path, with)
+						}
+						if !first && with.sendCreate {	// event for first already sent above
+							w.sendEvent(Event{Name: path, Op: Create})
+						}
+						first = false
+						return nil
+					})
+				}
+			}
+		case err, ok := <-w.errs_base:
+			if !ok {
+				return
+			}
+			w.sendError(err)
+		}
+	}
+}
+
+// Returns true if the event was sent, or false if watcher is closed.
+func (w *recursive) sendEvent(e Event) bool {
+	select {
+	case <-w.done:
+		return false
+	case w.ev <- e:
+		return true
+	}
+}
+
+// Returns true if the error was sent, or false if watcher is closed.
+func (w *recursive) sendError(err error) bool {
+	if err == nil {
+		return true
+	}
+	select {
+	case <-w.done:
+		return false
+	case w.errs <- err:
+		return true
+	}
+}
+
+func (w *recursive) isClosed() bool {
+	select {
+	case <-w.done:
+		return true
+	default:
+		return false
+	}
+}
+
+func (w *recursive) Close() error {
+	w.doneMu.Lock()
+	if w.isClosed() {
+		w.doneMu.Unlock()
+		return nil
+	}
+	err := w.b.Close()
+	close(w.done)
+	w.doneMu.Unlock()
+	<-w.doneResp
+	return err
+}
+
+func (w *recursive) Add(path string) error {
+	return w.AddWith(path)
+}
+
+func (w *recursive) AddWith(path string, opts ...addOpt) error {
+	base, recurse := recursivePath(path);
+	with := getOptions(opts...)
+	with.recurse = recurse
+	w.pathsMu.Lock()
+	w.paths[base] = with
+	w.pathsMu.Unlock()
+
+	if recurse {
+		if runtime.GOOS == "windows" {
+			// Windows backend expects the /... at the end of the path
+			err := w.b.AddWith(path, opts...)
+			if err != nil {
+				return err
+			}
+		}
+		if runtime.GOOS != "windows" || with.sendCreate {
+			return filepath.WalkDir(base, func(root string, d fs.DirEntry, err error) error {
+				if err != nil {
+					return err
+				}
+
+				// Recursively watch directories if backend does not support natively
+				if d.IsDir() && runtime.GOOS != "windows" {
+					err := w.b.AddWith(root, opts...)
+					if err != nil {
+						return err
+					}
+				}
+				
+				// Send create events for all directories and files recursively when
+				// a new directory is created. This ensures that any files created
+				// while the recursive watch is being established are reported as
+				// created, in addition to any existing files and directories from an
+				// existing directory hierarchy moved in. It includes the special case
+				// of `mkdir -p one/two/three` on some systems, where only the creation
+				// of `one` may be reported. More generally, it includes the case
+				// `mkdir -p /tmp/one/two/three && mv /tmp/one one`, i.e. an existing
+				// directory hierarchy moved in, which also only the create of `one`
+				// may be reported.
+				if with.sendCreate {
+					w.ev <- Event{Name: root, Op: Create}
+				}
+
+				return nil
+			})
+		}
+	} else {
+		return w.b.AddWith(base, opts...)
+	}
+	return nil
+}
+
+func (w *recursive) Remove(path string) error {
+	base, recurse := recursivePath(path);
+	with, err := w.getOptions(base)
+	if err != nil {
+		return err
+	}
+	if recurse && !with.recurse {
+		return fmt.Errorf("can't use /... with non-recursive watch %q", base)
+	}
+	w.pathsMu.Lock()
+	delete(w.paths, base)
+	w.pathsMu.Unlock()
+
+	if with.recurse {
+		if runtime.GOOS == "windows" {
+			// Windows backend expects the /... at the end of the path
+			return w.b.Remove(path)
+		} else {
+			// Recursively remove directories
+			return filepath.WalkDir(base, func(root string, d fs.DirEntry, err error) error {
+				if err != nil {
+					return err
+				} else if d.IsDir() {
+					return w.b.Remove(root)
+				} else {
+					return nil
+				}
+			})
+		}
+	} else {
+		return w.b.Remove(base)
+	}
+}
+
+func (w *recursive) WatchList() []string {
+	return w.b.WatchList()
+}
+
+func (w *recursive) xSupports(op Op) bool {
+	return w.b.xSupports(op);
+}

--- a/backend_windows_test.go
+++ b/backend_windows_test.go
@@ -26,13 +26,13 @@ func TestRemoveState(t *testing.T) {
 
 	check := func(want int) {
 		t.Helper()
-		if len(w.b.(*readDirChangesW).watches) != want {
+		if len(w.b.(*recursive).b.(*readDirChangesW).watches) != want {
 			var d []string
-			for k, v := range w.b.(*readDirChangesW).watches {
+			for k, v := range w.b.(*recursive).b.(*readDirChangesW).watches {
 				d = append(d, fmt.Sprintf("%#v = %#v", k, v))
 			}
 			t.Errorf("unexpected number of entries in w.watches (have %d, want %d):\n%v",
-				len(w.b.(*readDirChangesW).watches), want, strings.Join(d, "\n"))
+				len(w.b.(*recursive).b.(*readDirChangesW).watches), want, strings.Join(d, "\n"))
 		}
 	}
 
@@ -67,7 +67,7 @@ func TestWindowsRemWatch(t *testing.T) {
 	if err := w.Remove(tmp); err != nil {
 		t.Fatalf("Could not remove the watch: %v\n", err)
 	}
-	if err := w.b.(*readDirChangesW).remWatch(tmp); err == nil {
+	if err := w.b.(*recursive).b.(*readDirChangesW).remWatch(tmp); err == nil {
 		t.Fatal("Should be fail with closed handle\n")
 	}
 }

--- a/fsnotify.go
+++ b/fsnotify.go
@@ -250,7 +250,7 @@ var (
 // NewWatcher creates a new Watcher.
 func NewWatcher() (*Watcher, error) {
 	ev, errs := make(chan Event), make(chan error)
-	b, err := newBackend(ev, errs)
+	b, err := newRecursiveBackend(ev, errs)
 	if err != nil {
 		return nil, err
 	}
@@ -267,7 +267,7 @@ func NewWatcher() (*Watcher, error) {
 // buffers instead of adding a large userspace buffer.
 func NewBufferedWatcher(sz uint) (*Watcher, error) {
 	ev, errs := make(chan Event), make(chan error)
-	b, err := newBufferedBackend(sz, ev, errs)
+	b, err := newRecursiveBufferedBackend(sz, ev, errs)
 	if err != nil {
 		return nil, err
 	}
@@ -410,6 +410,7 @@ type (
 		op         Op
 		noFollow   bool
 		sendCreate bool
+		recurse    bool
 	}
 )
 

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -645,12 +645,7 @@ func isSolaris() bool {
 }
 
 func supportsRecurse(t *testing.T) {
-	switch runtime.GOOS {
-	case "windows", "linux":
-		// Run test.
-	default:
-		t.Skip("recursion not yet supported on " + runtime.GOOS)
-	}
+	// Run test.
 }
 
 func supportsFilter(t *testing.T) {

--- a/internal/ztest/diff_test.go
+++ b/internal/ztest/diff_test.go
@@ -147,7 +147,7 @@ func TestDiffMatch(t *testing.T) {
 		{"Hello", "He%(ANY)", ""},
 
 		{"Hello " + year + "!", "Hello %(YEAR)!", ""},
-		{"Hello " + year + "!", "Hello %(YEAR)", "\n--- have\n+++ want\n@@ -1 +1 @@\n-have Hello 2024!\n+want Hello 2024\n"},
+		{"Hello " + year + "!", "Hello %(YEAR)", "\n--- have\n+++ want\n@@ -1 +1 @@\n-have Hello " + year + "!\n+want Hello " + year + "\n"},
 
 		{"Hello xy", "Hello %(ANY 2)", ""},
 		{"Hello xy", "Hello %(ANY 2,)", ""},

--- a/testdata/watch-recurse/add-dir
+++ b/testdata/watch-recurse/add-dir
@@ -20,21 +20,21 @@ Output:
 	create   /sub/dir/newdir/file
 	remove   /sub/dir/newdir/file
 
-	write    /sub/dir/newdir
 	create   /sub/dir/newdir/file
 	remove   /sub/dir/newdir/file
 
-	write    /sub/dir/newdir
 	create   /sub/dir/newdir/file
 	write    /sub/dir/newdir/file
 
-	linux:  # Same as Windows, but without those stupid dir writes Windows sends.
+	windows:  # Has additional dir writes
 		create   /sub/dir/newdir
 		create   /sub/dir/newdir/file
 		remove   /sub/dir/newdir/file
 
+		write    /sub/dir/newdir
 		create   /sub/dir/newdir/file
 		remove   /sub/dir/newdir/file
 
+		write    /sub/dir/newdir
 		create   /sub/dir/newdir/file
 		write    /sub/dir/newdir/file

--- a/testdata/watch-recurse/remove-dir
+++ b/testdata/watch-recurse/remove-dir
@@ -11,18 +11,18 @@ Output:
 	create   /sub/dir/file
 	write    /sub/dir/file
 
-	write  /sub
-	write  /sub/dir
 	remove /sub/dir/file
-	write  /sub/dir
 	remove /sub/dir
-	write  /sub
 	remove /sub
 
-	linux:  # Same as Windows, but without those stupid dir writes Windows sends.
+	windows:  # Has additional dir writes
 		create   /sub/dir/file
 		write    /sub/dir/file
 
+		write  /sub
+		write  /sub/dir
 		remove /sub/dir/file
+		write  /sub/dir
 		remove /sub/dir
+		write  /sub
 		remove /sub

--- a/testdata/watch-recurse/remove-recursive
+++ b/testdata/watch-recurse/remove-recursive
@@ -19,11 +19,11 @@ echo asd >>/dir1/subdir/file
 echo asd >>/dir2/subdir/file
 
 Output:
-	write /dir1/subdir
 	write /dir1/subdir/file
-	write /dir2/subdir
 	write /dir2/subdir/file
 
-	linux:  # Same as Windows, but without those stupid dir writes Windows sends.
+	windows:  # Has additional dir writes
+		write /dir1/subdir
 		write /dir1/subdir/file
+		write /dir2/subdir
 		write /dir2/subdir/file

--- a/testdata/watch-recurse/remove-watched-dir
+++ b/testdata/watch-recurse/remove-watched-dir
@@ -28,21 +28,15 @@ Output:
 	remove      /watch/e
 	remove      /watch/f
 	remove      /watch/g
-	write       /watch/h
 	remove      /watch/h/a
-	write       /watch/h
 	remove      /watch/h
-	write       /watch/i
 	remove      /watch/i/a
-	write       /watch/i
 	remove      /watch/i
-	write       /watch/j
 	remove      /watch/j/a
-	write       /watch/j
 	remove      /watch/j
 	remove      /watch
 
-	linux:  # Same as Windows, but without those stupid dir writes Windows sends.
+	windows:  # Has additional dir writes
 		remove      /watch/a
 		remove      /watch/b
 		remove      /watch/c
@@ -50,10 +44,16 @@ Output:
 		remove      /watch/e
 		remove      /watch/f
 		remove      /watch/g
+		write       /watch/h
 		remove      /watch/h/a
+		write       /watch/h
 		remove      /watch/h
+		write       /watch/i
 		remove      /watch/i/a
+		write       /watch/i
 		remove      /watch/i
+		write       /watch/j
 		remove      /watch/j/a
+		write       /watch/j
 		remove      /watch/j
 		remove      /watch


### PR DESCRIPTION
Consider this a draft. It would be useful to hear whether there is interest in this approach before investing more time in it, and if so to get some help from others to debug platform specifics, especially for BSD, as I have little experience there. The public interface needs some consideration, currently I've just set this up to force the use of the recursive backend in all cases, as that was easiest for testing.

There is interest in supporting recursive watchers (e.g. #673, #114, #18). I have been interested in this for a PR on rclone also (rclone/rclone#8258), where I wrote a user-level recursive watcher around fsnotify that works on Linux and Mac, so in some sense this is looking at the feasibility of upstreaming that.

The idea of this approach is to provide a recursive backend that wraps any other non-recursive backend to provide support for recursive watchers, so that it is not necessary to add support for every backend separately. It does that using a pipeline approach, starting a goroutine that consumes from the existing event channel, does its work for recursion, and emits to a second event channel from which the user of fsnotify consumes.

For the Windows backend, where there is system-level support, it mostly passes through, although still acts as a wrapper to provide consistent behavior with create events. I realise the inotify backend has a user-level recursive implementation too; much of this is based on that actually, and might be seen as factoring that out to be usable by other backends too.