### PR TITLE
Fix race in inotify backend

### DIFF
--- a/fsnotify_test.go
+++ b/fsnotify_test.go
@@ -892,16 +892,6 @@ func TestRace(t *testing.T) {
 			t.Skip("hangs on windows")
 		}
 
-		// TODO: consistently fails with:
-		//
-		//   === RUN   TestRace/remove_self
-		//       helpers_test.go:435: no such file or directory
-		//   --- FAIL: TestRace (0.54s)
-		//       --- FAIL: TestRace/remove_self (0.54s)
-		if runtime.GOOS == "illumos" || runtime.GOOS == "solaris" {
-			t.Skip("fails")
-		}
-
 		tmp := t.TempDir()
 		w := newCollector(t, tmp)
 		w.collect(t)

--- a/fsnotify_test.go
+++ b/fsnotify_test.go
@@ -822,21 +822,102 @@ func BenchmarkAddRemove(b *testing.B) {
 	})
 }
 
-// Would panic on inotify: https://github.com/fsnotify/fsnotify/issues/616
-func TestRemoveRace(t *testing.T) {
-	t.Parallel()
+func TestRace(t *testing.T) {
+	// Would panic on inotify: https://github.com/fsnotify/fsnotify/issues/616
+	t.Run("add and remove watches", func(t *testing.T) {
+		t.Parallel()
 
-	tmp := t.TempDir()
-	w := newCollector(t, tmp)
-	w.collect(t)
+		tmp := t.TempDir()
+		w := newCollector(t, tmp)
+		w.collect(t)
 
-	dir := join(tmp, "/dir")
-	for i := 0; i < 100; i++ {
-		go os.MkdirAll(dir, 0o0755)
-		go os.RemoveAll(dir)
-		go w.w.Add(dir)
-		go w.w.Remove(dir)
-	}
-	time.Sleep(100 * time.Millisecond)
-	w.stop(t)
+		var (
+			dir = join(tmp, "/dir")
+			wg  sync.WaitGroup
+		)
+		wg.Add(400)
+		for i := 0; i < 100; i++ {
+			go func() { defer wg.Done(); os.MkdirAll(dir, 0o0755) }()
+			go func() { defer wg.Done(); os.RemoveAll(dir) }()
+			go func() { defer wg.Done(); w.w.Add(dir) }()
+			go func() { defer wg.Done(); w.w.Remove(dir) }()
+		}
+		wg.Wait()
+		w.stop(t)
+	})
+
+	// Race when deleting watched directory, creating it again, and re-adding
+	// it.
+	t.Run("remove self", func(t *testing.T) {
+		t.Parallel()
+
+		// TODO: seems to hang forever on Windows; possibly related to:
+		// https://github.com/fsnotify/fsnotify/issues/656
+		//
+		// Although it seems to be on different points:
+		//
+		//   goroutine 8 [chan receive]:
+		//   github.com/fsnotify/fsnotify.(*readDirChangesW).AddWith(0xc00002ea40, {0xc0000940f0, 0x48}, {0x0, 0x0, 0xaf2e7f?})
+		//           C:/Users/martin/fsnotify/backend_windows.go:141 +0x38d
+		//   github.com/fsnotify/fsnotify.(*readDirChangesW).Add(0xc000092000?, {0xc0000940f0?, 0x1?})
+		//           C:/Users/martin/fsnotify/backend_windows.go:111 +0x1f
+		//   github.com/fsnotify/fsnotify.(*Watcher).Add(...)
+		//           C:/Users/martin/fsnotify/fsnotify.go:313
+		//   github.com/fsnotify/fsnotify.TestRace.func2(0xc000003a40)
+		//           C:/Users/martin/fsnotify/fsnotify_test.go:865 +0x1ee
+		//   testing.tRunner(0xc000003a40, 0xb71930)
+		//           C:/Program Files/Go/src/testing/testing.go:1792 +0xcb
+		//   created by testing.(*T).Run in goroutine 7
+		//           C:/Program Files/Go/src/testing/testing.go:1851 +0x3f6
+		//
+		//   goroutine 9 [select, locked to thread]:
+		//   github.com/fsnotify/fsnotify.(*readDirChangesW).sendError(...)
+		//           C:/Users/martin/fsnotify/backend_windows.go:85
+		//   github.com/fsnotify/fsnotify.(*readDirChangesW).startRead(0xc00002ea40, 0xc0001a4100)
+		//           C:/Users/martin/fsnotify/backend_windows.go:453 +0x319
+		//   github.com/fsnotify/fsnotify.(*readDirChangesW).readEvents(0xc00002ea40)
+		//           C:/Users/martin/fsnotify/backend_windows.go:548 +0x290
+		//   created by github.com/fsnotify/fsnotify.newBufferedBackend in goroutine 8
+		//           C:/Users/martin/fsnotify/backend_windows.go:55 +0x198
+		//
+		//   goroutine 18 [chan send]:
+		//   github.com/fsnotify/fsnotify.(*eventCollector).collect.func1()
+		//           C:/Users/martin/fsnotify/helpers_test.go:436 +0x2cd
+		//   created by github.com/fsnotify/fsnotify.(*eventCollector).collect in goroutine 8
+		//          C:/Users/martin/fsnotify/helpers_test.go:427 +0x67
+		//
+		// The Windows backend hasn't really changed in a long time, so old
+		// problem, and not something we need to fix right now.
+		if runtime.GOOS == "windows" {
+			t.Skip("hangs on windows")
+		}
+
+		// TODO: consistently fails with:
+		//
+		//   === RUN   TestRace/remove_self
+		//       helpers_test.go:435: no such file or directory
+		//   --- FAIL: TestRace (0.54s)
+		//       --- FAIL: TestRace/remove_self (0.54s)
+		if runtime.GOOS == "illumos" || runtime.GOOS == "solaris" {
+			t.Skip("fails")
+		}
+
+		tmp := t.TempDir()
+		w := newCollector(t, tmp)
+		w.collect(t)
+
+		var (
+			dir = join(tmp, "/dir")
+			wg  sync.WaitGroup
+		)
+		w.w.Add(dir)
+		wg.Add(2000)
+		for i := 0; i < 1000; i++ {
+			go func() { defer wg.Done(); os.RemoveAll(dir) }()
+			go func() { defer wg.Done(); os.MkdirAll(dir, 0o0755) }()
+			w.w.Add(dir)
+		}
+		wg.Wait()
+		w.stop(t)
+	})
 }

--- a/fsnotify_test.go
+++ b/fsnotify_test.go
@@ -892,6 +892,14 @@ func TestRace(t *testing.T) {
 			t.Skip("hangs on windows")
 		}
 
+		// TODO: sometimes hands on "unix.Close(info.wd)" in kqueue.remove().
+		// Only seems to happen on macOS and not the other kqueue platforms.
+		//
+		// Just skip for now; want to rewrite kqueue backend anyway...
+		if runtime.GOOS == "darwin" {
+			t.Skip("hangs on macOS")
+		}
+
 		tmp := t.TempDir()
 		w := newCollector(t, tmp)
 		w.collect(t)

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -432,7 +432,7 @@ func (w *eventCollector) collect(t *testing.T) {
 					w.done <- struct{}{}
 					return
 				}
-				t.Error(e)
+				t.Errorf("eventCollector: unexpected error on Errors chan: %s", e)
 				w.done <- struct{}{}
 				return
 			case e, ok := <-w.w.Events:


### PR DESCRIPTION
It would access "watch.wd", but that's racy. I redid quite a bit of the inotify backend to add some new features, so regression from one of those changes (and/or would work "by accident" before).

Fixes #653
Fixes #664
Fixes #672