### PR TITLE
Don't add double watches for symlinks

### DIFF
--- a/backend_inotify.go
+++ b/backend_inotify.go
@@ -342,6 +342,10 @@ func (w *inotify) register(path string, flags uint32, recurse bool) error {
 			return nil, err
 		}
 
+		if e, ok := w.watches.wd[uint32(wd)]; ok {
+			return e, nil
+		}
+
 		if existing == nil {
 			return &watch{
 				wd:      uint32(wd),

--- a/testdata/watch-dir/remove-symlink
+++ b/testdata/watch-dir/remove-symlink
@@ -1,4 +1,5 @@
 # Remove a symlink.
+require symlink
 
 touch /file
 ln -s /file /link


### PR DESCRIPTION
inotify_add_watch() follows symlinks, and returns the current watch descriptor when adding a patch twice. So when doing "watch dir" and "watch link" (or reverse) second watch is basically a no-op; yet it's still registered as a "separate" watch, and would panic on removing the second.

The solution is to make the second Add() a no-op. This is also what kqueue does, and what happens if you watch the same path twice.

On illumos watching a symlink currently means registering double watches; this is a separate bug that should be fixed.

Fixes #652
Fixes #662