### PR TITLE
Fix relative links on kqueue

### DIFF
--- a/testdata/watch-dir/create-cyclic-symlink
+++ b/testdata/watch-dir/create-cyclic-symlink
@@ -9,7 +9,7 @@ echo foo >>/link
 
 Output:
 	write  /link
-	create /link
+	write  /link
 
 	linux, windows, fen:
 		remove  /link

--- a/testdata/watch-dir/create-file-in-subdir
+++ b/testdata/watch-dir/create-file-in-subdir
@@ -1,0 +1,10 @@
+watch /
+mkdir /dir
+touch /dir/file
+
+Output:
+	create  /dir
+
+	fen: # TODO
+		create  /dir
+		write   /dir

--- a/testdata/watch-dir/symlink-dir
+++ b/testdata/watch-dir/symlink-dir
@@ -5,8 +5,27 @@ mkdir /dir
 watch /
 ln -s /dir /link
 
+# Shouldn't give any events.
+touch link/file
+
 Output:
 	create  /link
+
+	# kqueue sends an event because it sends an event every time a directory
+	# changes, but fsnotify doesn't detect the symlink as a "directory". It's
+	# been like this for over a decade. When it was changed before people
+	# complained so I'm hesitant to fix it now as part of a bugfix.
+	#
+	# TODO: it shouldn't do this; it doesn't work like this on inotify.
+	kqueue:
+		create  /link
+		write   /link
+
+	# TODO: should also fix FEN, which seems to send a write for regular dirs as
+	# well.
+	fen:
+		create  /link
+		write   /dir
 
 	dragonfly: # TODO: can we fix this?
 		no-events

--- a/testdata/watch-symlink/to-dir-relative
+++ b/testdata/watch-symlink/to-dir-relative
@@ -9,6 +9,3 @@ touch /dir/file
 
 Output:
 	create    /link/file
-
-	kqueue:  # TODO: broken
-		no-events

--- a/testdata/watch-symlink/to-file-relative
+++ b/testdata/watch-symlink/to-file-relative
@@ -10,7 +10,5 @@ echo hello >>/file
 Output:
 	write    /link
 
-	kqueue:  # TODO: broken
-		no-events
 	windows:  # TODO: investigate.
 		no-events


### PR DESCRIPTION
Also only resolve symlinks explicitly given in Add()/AddWith(), and not those added "internally" as part of a listdir. Also don't ignore errors from os.Readlink() and os.Lstat; this was added in 2012 with bf36090 to ignore unresolvable symlinks when listing a directory, but we're no longer calling lstat() on the result of a link unless it's explicitly passed with Add().

Fixes #661