### PR TITLE
Correctly mark pre-existing entries when watching a link to a dir on kqueue

### DIFF
--- a/backend_kqueue.go
+++ b/backend_kqueue.go
@@ -450,7 +450,11 @@ func (w *kqueue) addWatch(name string, flags uint32, listDir bool) (string, erro
 		}
 
 		if watchDir {
-			if err := w.watchDirectoryFiles(name); err != nil {
+			d := name
+			if info.linkName != "" {
+				d = info.linkName
+			}
+			if err := w.watchDirectoryFiles(d); err != nil {
 				return "", err
 			}
 		}

--- a/testdata/watch-symlink/to-dir
+++ b/testdata/watch-symlink/to-dir
@@ -2,9 +2,10 @@
 require symlink
 
 mkdir /dir
+touch /dir/existing
 ln -s /dir /link
-watch /link
 
+watch /link
 touch /dir/file
 
 Output:


### PR DESCRIPTION
It would mark /dir/existing as seen, but would check for /link/existing. So on the first change in a directory it would list all pre-existing entries in the directory.

Regression from d2ee00e; just wasn't a testcase.