### PR TITLE
Move some shared code to a shared struct

### DIFF
--- a/backend_windows.go
+++ b/backend_windows.go
@@ -28,7 +28,7 @@ type readDirChangesW struct {
 
 	port  windows.Handle // Handle to completion port
 	input chan *input    // Inputs to the reader are sent on this channel
-	quit  chan chan<- error
+	done  chan chan<- error
 
 	mu      sync.Mutex // Protects access to watches, closed
 	watches watchMap   // Map of watches (key: i-number)
@@ -48,7 +48,7 @@ func newBackend(ev chan Event, errs chan error) (backend, error) {
 		port:    port,
 		watches: make(watchMap),
 		input:   make(chan *input, 1),
-		quit:    make(chan chan<- error, 1),
+		done:    make(chan chan<- error, 1),
 	}
 	go w.readEvents()
 	return w, nil
@@ -68,8 +68,8 @@ func (w *readDirChangesW) sendEvent(name, renamedFrom string, mask uint64) bool 
 	event := w.newEvent(name, uint32(mask))
 	event.renamedFrom = renamedFrom
 	select {
-	case ch := <-w.quit:
-		w.quit <- ch
+	case ch := <-w.done:
+		w.done <- ch
 	case w.Events <- event:
 	}
 	return true
@@ -81,10 +81,10 @@ func (w *readDirChangesW) sendError(err error) bool {
 		return true
 	}
 	select {
+	case <-w.done:
+		return false
 	case w.Errors <- err:
 		return true
-	case <-w.quit:
-		return false
 	}
 }
 
@@ -97,9 +97,9 @@ func (w *readDirChangesW) Close() error {
 	w.closed = true
 	w.mu.Unlock()
 
-	// Send "quit" message to the reader goroutine
+	// Send "done" message to the reader goroutine
 	ch := make(chan error)
-	w.quit <- ch
+	w.done <- ch
 	if err := w.wakeupReader(); err != nil {
 		return err
 	}
@@ -493,7 +493,7 @@ func (w *readDirChangesW) readEvents() {
 		watch := (*watch)(unsafe.Pointer(ov))
 		if watch == nil {
 			select {
-			case ch := <-w.quit:
+			case ch := <-w.done:
 				w.mu.Lock()
 				var indexes []indexMap
 				for _, index := range w.watches {

--- a/shared.go
+++ b/shared.go
@@ -1,0 +1,61 @@
+package fsnotify
+
+import "sync"
+
+type shared struct {
+	Events chan Event
+	Errors chan error
+	done   chan struct{}
+	doneMu sync.Mutex
+}
+
+func newShared(ev chan Event, errs chan error) shared {
+	return shared{
+		Events: ev,
+		Errors: errs,
+		done:   make(chan struct{}),
+	}
+}
+
+// Returns true if the event was sent, or false if watcher is closed.
+func (w *shared) sendEvent(e Event) bool {
+	select {
+	case <-w.done:
+		return false
+	case w.Events <- e:
+		return true
+	}
+}
+
+// Returns true if the error was sent, or false if watcher is closed.
+func (w *shared) sendError(err error) bool {
+	if err == nil {
+		return true
+	}
+	select {
+	case <-w.done:
+		return false
+	case w.Errors <- err:
+		return true
+	}
+}
+
+func (w *shared) isClosed() bool {
+	select {
+	case <-w.done:
+		return true
+	default:
+		return false
+	}
+}
+
+// Mark as closed; returns true if it was already closed.
+func (w *shared) close() bool {
+	w.doneMu.Lock()
+	defer w.doneMu.Unlock()
+	if w.isClosed() {
+		return true
+	}
+	close(w.done)
+	return false
+}


### PR DESCRIPTION
It's all the same code now (wasn't historically). Only Windows is still different, so don't do it for that.