### PR TITLE
Add test to ensure Add()/Remove() works when not reading events

### DIFF
--- a/fsnotify.go
+++ b/fsnotify.go
@@ -338,7 +338,8 @@ func (w *Watcher) Close() error { return w.b.Close() }
 // WatchList returns all paths explicitly added with [Watcher.Add] (and are not
 // yet removed).
 //
-// Returns nil if [Watcher.Close] was called.
+// The order is undefined, and may differ per call. Returns nil if
+// [Watcher.Close] was called.
 func (w *Watcher) WatchList() []string { return w.b.WatchList() }
 
 // Supports reports if all the listed operations are supported by this platform.

--- a/fsnotify_test.go
+++ b/fsnotify_test.go
@@ -562,6 +562,37 @@ func TestAdd(t *testing.T) {
 				remove /file
 		`))
 	})
+
+	t.Run("not reading events", func(t *testing.T) {
+		t.Parallel()
+
+		w := newWatcher(t)
+		defer w.Close()
+
+		tmp := t.TempDir()
+		mkdir(t, tmp, "/dir1")
+		mkdir(t, tmp, "/dir2")
+		addWatch(t, w, tmp, "/dir1")
+		addWatch(t, w, tmp, "/dir2")
+
+		{
+			have, want := w.WatchList(), []string{join(tmp, "/dir1"), join(tmp, "/dir2")}
+			sort.Strings(have)
+			if !reflect.DeepEqual(have, want) {
+				t.Errorf("\nhave: %s\nwant: %s", have, want)
+			}
+		}
+		if err := w.Remove(join(tmp, "/dir1")); err != nil {
+			t.Fatal(err)
+		}
+		{
+			have, want := w.WatchList(), []string{join(tmp, "/dir2")}
+			sort.Strings(have)
+			if !reflect.DeepEqual(have, want) {
+				t.Errorf("\nhave: %s\nwant: %s", have, want)
+			}
+		}
+	})
 }
 
 func TestRemove(t *testing.T) {


### PR DESCRIPTION
Taken from a branch I worked on some time ago where this was a bug.