### PR TITLE
bug:fix lost rename event

### DIFF
--- a/backend_inotify.go
+++ b/backend_inotify.go
@@ -203,7 +203,7 @@ func (w *inotify) AddWith(path string, opts ...addOpt) error {
 			flags |= unix.IN_DELETE | unix.IN_DELETE_SELF
 		}
 		if with.op.Has(Rename) {
-			flags |= unix.IN_MOVED_TO | unix.IN_MOVED_FROM | unix.IN_MOVE_SELF
+			flags |= unix.IN_MOVED_TO | unix.IN_MOVED_FROM | unix.IN_MOVE_SELF | unix.SYS_RENAME
 		}
 		if with.op.Has(Chmod) {
 			flags |= unix.IN_ATTRIB
@@ -538,7 +538,7 @@ func (w *inotify) newEvent(name string, mask, cookie uint32) Event {
 	if mask&unix.IN_CLOSE_NOWRITE == unix.IN_CLOSE_NOWRITE {
 		e.Op |= xUnportableCloseRead
 	}
-	if mask&unix.IN_MOVE_SELF == unix.IN_MOVE_SELF || mask&unix.IN_MOVED_FROM == unix.IN_MOVED_FROM {
+	if mask&unix.IN_MOVE_SELF == unix.IN_MOVE_SELF || mask&unix.IN_MOVED_FROM == unix.IN_MOVED_FROM || mask&unix.SYS_RENAME > 0 {
 		e.Op |= Rename
 	}
 	if mask&unix.IN_ATTRIB == unix.IN_ATTRIB {


### PR DESCRIPTION
```
import os
 
def main():
    os.rename("/home/nmx/nmx.conflist", "/home/nmx/ansible/nmx.conflist")


if __name__ == '__main__':
    main()
```

use demo

```
package main

import (
    "log"

    "github.com/fsnotify/fsnotify"
)

func main() {
    // Create new watcher.
    watcher, err := fsnotify.NewWatcher()
    if err != nil {
        log.Fatal(err)
    }
    defer watcher.Close()

    // Start listening for events.
    go func() {
        for {
            select {
            case event, ok := <-watcher.Events:
                if !ok {
                    return
                }
                log.Println("event:", event)
                if event.Has(fsnotify.Write) {
                    log.Println("modified file:", event.Name)
                }
            case err, ok := <-watcher.Errors:
                if !ok {
                    return
                }
                log.Println("error:", err)
            }
        }
    }()

    // Add a path.
    err = watcher.Add("/home/nmx/ansible/")
    if err != nil {
        log.Fatal(err)
    }

    // Block main goroutine forever.
    <-make(chan struct{})
}
```
will only print create log 

```
2025/04/18 14:17:58 event: CREATE        "/home/nmx/ansible/nmx.conflist"
```
