### PR TITLE
Linux builds are failing of undeclared xUnportable variables

### DIFF
--- a/backend_fen.go
+++ b/backend_fen.go
@@ -459,8 +459,8 @@ func (w *fen) WatchList() []string {
 }
 
 func (w *fen) Supports(op Op) bool {
-	if op.Has(UnportableOpen) || op.Has(UnportableRead) ||
-		op.Has(UnportableCloseWrite) || op.Has(UnportableCloseRead) {
+	if op.Has(xUnportableOpen) || op.Has(xUnportableRead) ||
+		op.Has(xUnportableCloseWrite) || op.Has(xUnportableCloseRead) {
 		return false
 	}
 	return true

--- a/backend_inotify.go
+++ b/backend_inotify.go
@@ -527,16 +527,16 @@ func (w *inotify) newEvent(name string, mask, cookie uint32) Event {
 		e.Op |= Write
 	}
 	if mask&unix.IN_OPEN == unix.IN_OPEN {
-		e.Op |= UnportableOpen
+		e.Op |= xUnportableOpen
 	}
 	if mask&unix.IN_ACCESS == unix.IN_ACCESS {
-		e.Op |= UnportableRead
+		e.Op |= xUnportableRead
 	}
 	if mask&unix.IN_CLOSE_WRITE == unix.IN_CLOSE_WRITE {
-		e.Op |= UnportableCloseWrite
+		e.Op |= xUnportableCloseWrite
 	}
 	if mask&unix.IN_CLOSE_NOWRITE == unix.IN_CLOSE_NOWRITE {
-		e.Op |= UnportableCloseRead
+		e.Op |= xUnportableCloseRead
 	}
 	if mask&unix.IN_MOVE_SELF == unix.IN_MOVE_SELF || mask&unix.IN_MOVED_FROM == unix.IN_MOVED_FROM {
 		e.Op |= Rename

--- a/backend_windows.go
+++ b/backend_windows.go
@@ -672,8 +672,8 @@ func (w *readDirChangesW) toFSnotifyFlags(action uint32) uint64 {
 }
 
 func (w *readDirChangesW) Supports(op Op) bool {
-	if op.Has(UnportableOpen) || op.Has(UnportableRead) ||
-		op.Has(UnportableCloseWrite) || op.Has(UnportableCloseRead) {
+	if op.Has(xUnportableOpen) || op.Has(xUnportableRead) ||
+		op.Has(xUnportableCloseWrite) || op.Has(xUnportableCloseRead) {
 		return false
 	}
 	return true

--- a/cmd/fsnotify/finishwrite.go
+++ b/cmd/fsnotify/finishwrite.go
@@ -28,16 +28,19 @@ func finishWrite(paths ...string) {
 	}
 	defer w.Close()
 
-	// Check if CloseWrite is supported.
+	// CloseWrite is supported by all platforms.
+	// Leaving this just because it was already there.
 	var (
 		op fsnotify.Op
-		cw = w.Supports(fsnotify.UnportableCloseWrite)
+		cw = false
+		// cw = w.Supports(fsnotify.xUnportableCloseWrite)
 	)
-	if cw {
-		op |= fsnotify.UnportableCloseWrite
-	} else {
-		op |= fsnotify.Create | fsnotify.Write
-	}
+	/*
+		if cw {
+			op |= fsnotify.xUnportableCloseWrite
+		} else {
+	*/
+	op |= fsnotify.Create | fsnotify.Write
 
 	go finishWriteLoop(w, cw)
 
@@ -78,7 +81,7 @@ func finishWriteLoop(w *fsnotify.Watcher, cw bool) {
 
 			// CloseWrite is supported: easy case.
 			if cw {
-				if e.Has(fsnotify.UnportableCloseWrite) {
+				if e.Has(fsnotify.xUnportableCloseWrite) {
 					printTime(e.String())
 				}
 				continue

--- a/fsnotify.go
+++ b/fsnotify.go
@@ -201,12 +201,12 @@ const (
 	// File descriptor was opened.
 	//
 	// Only works on Linux.
-	UnportableOpen
+	xUnportableOpen
 
 	// File was read from.
 	//
 	// Only works on Linux.
-	UnportableRead
+	xUnportableRead
 
 	// File opened for writing was closed.
 	//
@@ -216,12 +216,12 @@ const (
 	// waiting for Write events to stop. It's also faster (if you're not
 	// listening to Write events): copying a file of a few GB can easily
 	// generate tens of thousands of Write events in a short span of time.
-	UnportableCloseWrite
+	xUnportableCloseWrite
 
 	// File opened for reading was closed.
 	//
 	// Only works on Linux.
-	UnportableCloseRead
+	xUnportableCloseRead
 )
 
 var (
@@ -363,16 +363,16 @@ func (o Op) String() string {
 	if o.Has(Write) {
 		b.WriteString("|WRITE")
 	}
-	if o.Has(UnportableOpen) {
+	if o.Has(xUnportableOpen) {
 		b.WriteString("|OPEN")
 	}
-	if o.Has(UnportableRead) {
+	if o.Has(xUnportableRead) {
 		b.WriteString("|READ")
 	}
-	if o.Has(UnportableCloseWrite) {
+	if o.Has(xUnportableCloseWrite) {
 		b.WriteString("|CLOSE_WRITE")
 	}
-	if o.Has(UnportableCloseRead) {
+	if o.Has(xUnportableCloseRead) {
 		b.WriteString("|CLOSE_READ")
 	}
 	if o.Has(Rename) {

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -556,13 +556,13 @@ func newEvents(t *testing.T, s string) Events {
 			case "CHMOD":
 				op |= Chmod
 			case "OPEN":
-				op |= UnportableOpen
+				op |= xUnportableOpen
 			case "READ":
-				op |= UnportableRead
+				op |= xUnportableRead
 			case "CLOSE_WRITE":
-				op |= UnportableCloseWrite
+				op |= xUnportableCloseWrite
 			case "CLOSE_READ":
-				op |= UnportableCloseRead
+				op |= xUnportableCloseRead
 			default:
 				t.Fatalf("newEvents: line %d has unknown event %q: %s", no+1, ee, line)
 			}


### PR DESCRIPTION
Hello! Thank you for your work!

There have been some changes recently and I now get this:
```
/root/go/pkg/mod/github.com/fsnotify/fsnotify@v1.8.1-0.20250401092707-1929b69cebb5/backend_inotify.go:211:18: undefined: xUnportableOpen
/root/go/pkg/mod/github.com/fsnotify/fsnotify@v1.8.1-0.20250401092707-1929b69cebb5/backend_inotify.go:214:18: undefined: xUnportableRead
/root/go/pkg/mod/github.com/fsnotify/fsnotify@v1.8.1-0.20250401092707-1929b69cebb5/backend_inotify.go:217:18: undefined: xUnportableCloseWrite
/root/go/pkg/mod/github.com/fsnotify/fsnotify@v1.8.1-0.20250401092707-1929b69cebb5/backend_inotify.go:220:18: undefined: xUnportableCloseRead
```

I assume that are just some leftovers, so I modified them to match to the previous commit (1929b69cebb566d1c9782031bbab5c42250a5be6)