### PR TITLE
Revert "Remove gccgo from CI"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,21 @@ jobs:
           $Env:FSNOTIFY_DEBUG = 1
           go test -parallel 1 -race -v ./...
 
+  # Test gccgo
+  gcc:
+    runs-on: 'ubuntu-24.04'
+    name:    'test (ubuntu-24.04, gccgo 13.2)'
+    timeout-minutes: 10
+    steps:
+      - uses: 'actions/checkout@v4'
+      - name: test
+        run: |
+          sudo apt-get -y install gccgo-13
+          go-13 version
+          FSNOTIFY_BUFFER=4096 go-13 test -parallel 1    ./...
+                               go-13 test -parallel 1    ./...
+          FSNOTIFY_DEBUG=1     go-13 test -parallel 1 -v ./...
+
   macos:
     name: 'test'
     strategy:


### PR DESCRIPTION
This reverts commit https://github.com/purpleidea/fsnotify/commit/a10c87150a06b15edb4c9f016147b13bbab77902.

I think gccgo is quite useful, and it's completely not dead. There's no reason this library needs generics.