### PR TITLE
kqueue: allow watching directories only

### DIFF
--- a/backend_kqueue.go
+++ b/backend_kqueue.go
@@ -24,6 +24,7 @@ type kqueue struct {
 	kq        int    // File descriptor (as returned by the kqueue() syscall).
 	closepipe [2]int // Pipe used for closing kq.
 	watches   *watches
+	dirsOnly  bool
 }
 
 type (
@@ -266,6 +267,10 @@ func (w *kqueue) AddWith(name string, opts ...addOpt) error {
 	with := getOptions(opts...)
 	if !w.xSupports(with.op) {
 		return fmt.Errorf("%w: %s", xErrUnsupported, with.op)
+	}
+
+	if with.dirsOnly {
+		w.dirsOnly = true
 	}
 
 	_, err := w.addWatch(name, noteAllEvents, false)
@@ -656,6 +661,10 @@ func (w *kqueue) internalWatch(name string, fi os.FileInfo) (string, error) {
 		// the flags used if currently watching subdirectory
 		info, _ := w.watches.byPath(name)
 		return w.addWatch(name, info.dirFlags|unix.NOTE_DELETE|unix.NOTE_RENAME, true)
+	}
+
+	if w.dirsOnly {
+		return filepath.Clean(name), nil
 	}
 
 	// Watch file to mimic Linux inotify.

--- a/backend_kqueue_test.go
+++ b/backend_kqueue_test.go
@@ -8,6 +8,34 @@ import (
 	"testing"
 )
 
+func TestDirsOnly(t *testing.T) {
+	var (
+		tmp = t.TempDir()
+		dir = join(tmp, "dir")
+	)
+	mkdir(t, dir)
+	touch(t, dir, "file1")
+	touch(t, dir, "file2")
+
+	w := newWatcher(t)
+	kq := w.b.(*kqueue)
+
+	if err := w.AddWith(dir, WithDirsOnly()); err != nil {
+		t.Fatalf("AddWith(WithDirsOnly()): %s", err)
+	}
+
+	if !kq.dirsOnly {
+		t.Errorf("dirsOnly should be true after AddWith(withDirsOnly())")
+	}
+
+	// Only the directory itself is watched, not individual files.
+	if n := len(kq.watches.wd); n != 1 {
+		t.Errorf("with dirsOnly, expected 1 watch (directory only), got %d", n)
+	}
+
+	w.Close()
+}
+
 func TestRemoveState(t *testing.T) {
 	var (
 		tmp  = t.TempDir()

--- a/fsnotify.go
+++ b/fsnotify.go
@@ -410,6 +410,7 @@ type (
 		bufsize    int
 		op         Op
 		sendCreate bool
+		dirsOnly   bool
 	}
 )
 
@@ -470,6 +471,19 @@ func withOps(op Op) addOpt {
 // "Internal" option for recursive watches on inotify.
 func withCreate() addOpt {
 	return func(opt *withOpts) { opt.sendCreate = true }
+}
+
+// WithDirsOnly configures kqueue watchers to only watch directories, not
+// individual files within those directories.
+//
+// Reduces file descriptor usage on BSD from 1+N to 1, where kqueue requires
+// one file descriptor per watched file. With this option, Create and Remove
+// events for files are still detected via modifications to the parent
+// directory, but not any Write events.
+//
+// No-op on non-kqueue systems.
+func WithDirsOnly() addOpt {
+	return func(opt *withOpts) { opt.dirsOnly = true }
 }
 
 var enableRecurse = false


### PR DESCRIPTION
The kqueue backend implicitly watches all files, requiring 1+N file descriptors. For usages which only care about new, deleted or moved files, this requires a huge amount of unnecessary file descriptors.

Add a flag to watch directories only, ignoring Write (mutation) events for files, but delivering events for new or deleted files.