### PR TITLE
Improve inotify initialization error message

### DIFF
--- a/backend_inotify.go
+++ b/backend_inotify.go
@@ -142,7 +142,7 @@ func newBackend(ev chan Event, errs chan error) (backend, error) {
 	// I/O operations won't terminate on close.
 	fd, errno := unix.InotifyInit1(unix.IN_CLOEXEC | unix.IN_NONBLOCK)
 	if fd == -1 {
-		return nil, errno
+		return nil, fmt.Errorf("couldn't initialize inotify: %w", errno)
 	}
 
 	w := &inotify{


### PR DESCRIPTION
## Description

Improves the error message when inotify initialization fails in [newBackend()](https://github.com/shawnhuang92/fsnotify/blob/fix/inotify-init-error/backend_inotify.go#L140-L160).

### Motivation

`fsnotify` is used by Kubernetes. Previously, when inotify init failed, the error lacked context:
```log
err="failed complete: too many open files"
```

This made it hard to identify the root cause.

### After This PR
```log
err="failed complete: couldn't initialize inotify: too many open files"
```
### Benefits

- **Clearer context**: Immediately identifies inotify as the failure source
- **Better debugging**: Helps users and AI tools diagnose issues faster
