### PR TITLE
complete recursive watch support

### DIFF
--- a/backend_fen.go
+++ b/backend_fen.go
@@ -12,6 +12,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -26,8 +27,9 @@ type fen struct {
 
 	mu      sync.Mutex
 	port    *unix.EventPort
-	dirs    map[string]Op // Explicitly watched directories
-	watches map[string]Op // Explicitly watched non-directories
+	dirs    map[string]Op        // Explicitly watched directories
+	watches map[string]Op        // Explicitly watched non-directories
+	recurse map[string]struct{}  // Root paths of recursive watches
 }
 
 var defaultBufferSize = 0
@@ -39,6 +41,7 @@ func newBackend(ev chan Event, errs chan error) (backend, error) {
 		Errors:  errs,
 		dirs:    make(map[string]Op),
 		watches: make(map[string]Op),
+		recurse: make(map[string]struct{}),
 	}
 
 	var err error
@@ -74,6 +77,11 @@ func (w *fen) AddWith(name string, opts ...addOpt) error {
 		return fmt.Errorf("%w: %s", xErrUnsupported, with.op)
 	}
 
+	name, recurse := recursivePath(name)
+	if recurse {
+		return w.addRecursive(name, with)
+	}
+
 	// Currently we resolve symlinks that were explicitly requested to be
 	// watched. Otherwise we would use LStat here.
 	stat, err := os.Stat(name)
@@ -105,10 +113,66 @@ func (w *fen) AddWith(name string, opts ...addOpt) error {
 	return nil
 }
 
+// addRecursive walks the directory tree and adds watches for all directories.
+func (w *fen) addRecursive(name string, with withOpts) error {
+	err := filepath.WalkDir(name, func(root string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() {
+			if root == name {
+				return fmt.Errorf("fsnotify: not a directory: %q", name)
+			}
+			return nil
+		}
+
+		if with.sendCreate && root != name {
+			w.sendEvent(Event{Name: root, Op: Create})
+		}
+
+		stat, err := d.Info()
+		if err != nil {
+			return err
+		}
+		err = w.handleDirectory(root, stat, true, w.associateFile)
+		if err != nil {
+			return err
+		}
+		w.mu.Lock()
+		w.dirs[root] = with.op
+		w.mu.Unlock()
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	w.mu.Lock()
+	w.recurse[name] = struct{}{}
+	w.mu.Unlock()
+	return nil
+}
+
 func (w *fen) Remove(name string) error {
 	if w.isClosed() {
 		return nil
 	}
+
+	name, recurse := recursivePath(name)
+
+	// Check if this is a recursive watch (either via /... or because it was
+	// added that way).
+	w.mu.Lock()
+	_, isRecurse := w.recurse[name]
+	w.mu.Unlock()
+
+	if recurse && !isRecurse {
+		return fmt.Errorf("can't use /... with non-recursive watch %q", name)
+	}
+
+	if isRecurse {
+		return w.removeRecursive(name)
+	}
+
 	if !w.port.PathIsWatched(name) {
 		return fmt.Errorf("%w: %s", ErrNonExistentWatch, name)
 	}
@@ -117,9 +181,6 @@ func (w *fen) Remove(name string) error {
 			time.Now().Format("15:04:05.000000000"), name)
 	}
 
-	// The user has expressed an intent. Immediately remove this name from
-	// whichever watch list it might be in. If it's not in there the delete
-	// doesn't cause harm.
 	w.mu.Lock()
 	delete(w.watches, name)
 	delete(w.dirs, name)
@@ -130,20 +191,41 @@ func (w *fen) Remove(name string) error {
 		return err
 	}
 
-	// Remove associations for every file in the directory.
 	if stat.IsDir() {
-		err := w.handleDirectory(name, stat, false, w.dissociateFile)
-		if err != nil {
-			return err
+		return w.handleDirectory(name, stat, false, w.dissociateFile)
+	}
+
+	return w.port.DissociatePath(name)
+}
+
+// removeRecursive removes all watches under the given recursive root.
+func (w *fen) removeRecursive(name string) error {
+	w.mu.Lock()
+	var toRemove []string
+	for p := range w.dirs {
+		if p == name || strings.HasPrefix(p, name+"/") {
+			toRemove = append(toRemove, p)
 		}
-		return nil
 	}
+	delete(w.recurse, name)
+	w.mu.Unlock()
 
-	err = w.port.DissociatePath(name)
-	if err != nil {
-		return err
+	for _, p := range toRemove {
+		stat, err := os.Stat(p)
+		if err != nil {
+			// Already gone, just clean up state.
+			w.mu.Lock()
+			delete(w.dirs, p)
+			w.mu.Unlock()
+			continue
+		}
+		if stat.IsDir() {
+			_ = w.handleDirectory(p, stat, false, w.dissociateFile)
+		}
+		w.mu.Lock()
+		delete(w.dirs, p)
+		w.mu.Unlock()
 	}
-
 	return nil
 }
 
@@ -363,8 +445,8 @@ func (w *fen) updateDirectory(path string) error {
 	}
 
 	for _, entry := range files {
-		path := filepath.Join(path, entry.Name())
-		if w.port.PathIsWatched(path) {
+		entryPath := filepath.Join(path, entry.Name())
+		if w.port.PathIsWatched(entryPath) {
 			continue
 		}
 
@@ -372,7 +454,25 @@ func (w *fen) updateDirectory(path string) error {
 		if err != nil {
 			return err
 		}
-		err = w.associateFile(path, finfo, false)
+
+		// If a new directory appears under a recursive watch, walk it and
+		// add watches for the entire subtree.
+		if finfo.IsDir() && w.isUnderRecurse(path) {
+			if err := w.addRecursiveSubdir(entryPath); err != nil {
+				if errors.Is(err, fs.ErrNotExist) {
+					continue
+				}
+				if !w.sendError(err) {
+					return nil
+				}
+			}
+			if !w.sendEvent(Event{Name: entryPath, Op: Create}) {
+				return nil
+			}
+			continue
+		}
+
+		err = w.associateFile(entryPath, finfo, false)
 		if errors.Is(err, fs.ErrNotExist) {
 			// File may have disappeared between getting the dir listing and
 			// adding the port: that's okay to ignore.
@@ -381,11 +481,48 @@ func (w *fen) updateDirectory(path string) error {
 		if !w.sendError(err) {
 			return nil
 		}
-		if !w.sendEvent(Event{Name: path, Op: Create}) {
+		if !w.sendEvent(Event{Name: entryPath, Op: Create}) {
 			return nil
 		}
 	}
 	return nil
+}
+
+// isUnderRecurse reports whether path falls under any recursive watch root.
+func (w *fen) isUnderRecurse(path string) bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	for p := range w.recurse {
+		if path == p || strings.HasPrefix(path, p+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+// addRecursiveSubdir walks a newly created directory and adds watches for all
+// nested subdirectories when under a recursive watch.
+func (w *fen) addRecursiveSubdir(root string) error {
+	return filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() {
+			return nil
+		}
+		stat, err := d.Info()
+		if err != nil {
+			return err
+		}
+		err = w.handleDirectory(path, stat, true, w.associateFile)
+		if err != nil {
+			return err
+		}
+		w.mu.Lock()
+		w.dirs[path] = Create | Write | Remove | Rename | Chmod
+		w.mu.Unlock()
+		return nil
+	})
 }
 
 func (w *fen) associateFile(path string, stat os.FileInfo, follow bool) error {

--- a/backend_fen.go
+++ b/backend_fen.go
@@ -458,6 +458,9 @@ func (w *fen) updateDirectory(path string) error {
 		// If a new directory appears under a recursive watch, walk it and
 		// add watches for the entire subtree.
 		if finfo.IsDir() && w.isUnderRecurse(path) {
+			if !w.sendEvent(Event{Name: entryPath, Op: Create}) {
+				return nil
+			}
 			if err := w.addRecursiveSubdir(entryPath); err != nil {
 				if errors.Is(err, fs.ErrNotExist) {
 					continue
@@ -465,9 +468,6 @@ func (w *fen) updateDirectory(path string) error {
 				if !w.sendError(err) {
 					return nil
 				}
-			}
-			if !w.sendEvent(Event{Name: entryPath, Op: Create}) {
-				return nil
 			}
 			continue
 		}
@@ -510,6 +510,14 @@ func (w *fen) addRecursiveSubdir(root string) error {
 		if !d.IsDir() {
 			return nil
 		}
+
+		// Emit Create for nested dirs the caller doesn't know about.
+		if path != root {
+			if !w.sendEvent(Event{Name: path, Op: Create}) {
+				return nil
+			}
+		}
+
 		stat, err := d.Info()
 		if err != nil {
 			return err

--- a/backend_inotify.go
+++ b/backend_inotify.go
@@ -102,8 +102,9 @@ func (w *watches) removePath(path string) ([]uint32, error) {
 
 	wds := make([]uint32, 0, 8)
 	wds = append(wds, wd)
+	prefix := path + "/"
 	for p, rwd := range w.path {
-		if strings.HasPrefix(p, path) {
+		if strings.HasPrefix(p, prefix) {
 			delete(w.path, p)
 			delete(w.wd, rwd)
 			wds = append(wds, rwd)
@@ -501,12 +502,16 @@ func (w *inotify) handleEvent(inEvent *unix.InotifyEvent, buf *[65536]byte, offs
 			// in the future. For now I'm okay with this as it's not publicly
 			// available. Correctness first, performance second.
 			if ev.renamedFrom != "" {
+				oldPrefix := ev.renamedFrom + "/"
 				for k, ww := range w.watches.wd {
 					if k == watch.wd || ww.path == ev.Name {
 						continue
 					}
-					if strings.HasPrefix(ww.path, ev.renamedFrom) {
-						ww.path = strings.Replace(ww.path, ev.renamedFrom, ev.Name, 1)
+					if ww.path == ev.renamedFrom {
+						ww.path = ev.Name
+						w.watches.wd[k] = ww
+					} else if strings.HasPrefix(ww.path, oldPrefix) {
+						ww.path = ev.Name + "/" + strings.TrimPrefix(ww.path, oldPrefix)
 						w.watches.wd[k] = ww
 					}
 				}

--- a/backend_kqueue.go
+++ b/backend_kqueue.go
@@ -818,6 +818,13 @@ func (w *kqueue) addRecursiveSubdir(root string) error {
 			return nil
 		}
 
+		// Emit Create for nested dirs the caller doesn't know about.
+		if path != root {
+			if !w.sendEvent(Event{Name: path, Op: Create}) {
+				return nil
+			}
+		}
+
 		// Add directory watch.
 		_, err = w.addWatch(path, noteAllEvents, false)
 		if err != nil {

--- a/backend_kqueue.go
+++ b/backend_kqueue.go
@@ -5,10 +5,12 @@ package fsnotify
 import (
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -28,29 +30,32 @@ type kqueue struct {
 
 type (
 	watches struct {
-		mu     sync.RWMutex
-		wd     map[int]watch               // wd → watch
-		path   map[string]int              // pathname → wd
-		byDir  map[string]map[int]struct{} // dirname(path) → wd
-		seen   map[string]struct{}         // Keep track of if we know this file exists.
-		byUser map[string]struct{}         // Watches added with Watcher.Add()
+		mu      sync.RWMutex
+		wd      map[int]watch               // wd → watch
+		path    map[string]int              // pathname → wd
+		byDir   map[string]map[int]struct{} // dirname(path) → wd
+		seen    map[string]struct{}         // Keep track of if we know this file exists.
+		byUser  map[string]struct{}         // Watches added with Watcher.Add()
+		recurse map[string]struct{}         // Root paths of recursive watches.
 	}
 	watch struct {
-		wd       int
-		name     string
-		linkName string // In case of links; name is the target, and this is the link.
-		isDir    bool
-		dirFlags uint32
+		wd         int
+		name       string
+		linkName   string // In case of links; name is the target, and this is the link.
+		isDir      bool
+		dirFlags   uint32
+		watchFlags watchFlag
 	}
 )
 
 func newWatches() *watches {
 	return &watches{
-		wd:     make(map[int]watch),
-		path:   make(map[string]int),
-		byDir:  make(map[string]map[int]struct{}),
-		seen:   make(map[string]struct{}),
-		byUser: make(map[string]struct{}),
+		wd:      make(map[int]watch),
+		path:    make(map[string]int),
+		byDir:   make(map[string]map[int]struct{}),
+		seen:    make(map[string]struct{}),
+		byUser:  make(map[string]struct{}),
+		recurse: make(map[string]struct{}),
 	}
 }
 
@@ -183,6 +188,53 @@ func (w *watches) seenBefore(path string) bool {
 	return ok
 }
 
+func (w *watches) isRecurse(path string) bool {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	fd, ok := w.path[path]
+	if !ok {
+		return false
+	}
+	return w.wd[fd].watchFlags&flagRecurse != 0
+}
+
+// isUnderRecurse reports whether path falls under any recursive watch root.
+func (w *watches) isUnderRecurse(path string) bool {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	for p := range w.recurse {
+		if path == p || strings.HasPrefix(path, p+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+// removePaths removes a path and, if it was added recursively, all sub-paths.
+// Returns paths that were removed.
+func (w *watches) removePaths(path string) []string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	fd, ok := w.path[path]
+	if !ok {
+		return nil
+	}
+	ww := w.wd[fd]
+	isRecurse := ww.watchFlags&flagRecurse != 0
+
+	removed := []string{path}
+	if isRecurse {
+		for p := range w.path {
+			if p != path && strings.HasPrefix(p, path+"/") {
+				removed = append(removed, p)
+			}
+		}
+		delete(w.recurse, path)
+	}
+	return removed
+}
+
 var defaultBufferSize = 0
 
 func newBackend(ev chan Event, errs chan error) (backend, error) {
@@ -268,6 +320,11 @@ func (w *kqueue) AddWith(name string, opts ...addOpt) error {
 		return fmt.Errorf("%w: %s", xErrUnsupported, with.op)
 	}
 
+	name, recurse := recursivePath(name)
+	if recurse {
+		return w.addRecursive(name, with)
+	}
+
 	_, err := w.addWatch(name, noteAllEvents, false)
 	if err != nil {
 		return err
@@ -276,12 +333,92 @@ func (w *kqueue) AddWith(name string, opts ...addOpt) error {
 	return nil
 }
 
+// addRecursive walks the directory tree and adds watches for all directories.
+func (w *kqueue) addRecursive(name string, with withOpts) error {
+	err := filepath.WalkDir(name, func(root string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() {
+			if root == name {
+				return fmt.Errorf("fsnotify: not a directory: %q", name)
+			}
+			return nil
+		}
+
+		// Send a Create event when adding new directory from a recursive
+		// watch; this is for "mkdir -p one/two/three".
+		if with.sendCreate && root != name {
+			w.sendEvent(Event{Name: root, Op: Create})
+		}
+
+		_, err = w.addWatch(root, noteAllEvents, false)
+		if err != nil {
+			return err
+		}
+		if root == name {
+			w.watches.addUserWatch(root)
+		}
+
+		// Mark this watch as recursive.
+		w.watches.mu.Lock()
+		if fd, ok := w.watches.path[root]; ok {
+			ww := w.watches.wd[fd]
+			wf := flagRecurse
+			if root == name {
+				wf |= flagByUser
+			}
+			ww.watchFlags = wf
+			w.watches.wd[fd] = ww
+		}
+		w.watches.mu.Unlock()
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	w.watches.mu.Lock()
+	w.watches.recurse[name] = struct{}{}
+	w.watches.mu.Unlock()
+	return nil
+}
+
 func (w *kqueue) Remove(name string) error {
 	if debug {
 		fmt.Fprintf(os.Stderr, "FSNOTIFY_DEBUG: %s  Remove(%q)\n",
 			time.Now().Format("15:04:05.000000000"), name)
 	}
+
+	name, recurse := recursivePath(name)
+
+	// If called with /..., the watch must have been added recursively.
+	if recurse && !w.watches.isRecurse(name) {
+		return fmt.Errorf("can't use /... with non-recursive watch %q", name)
+	}
+
+	// If the watch was added recursively, remove it and all children
+	// even without /... in the path (matches inotify behavior).
+	if w.watches.isRecurse(name) || recurse {
+		return w.removeRecursive(name)
+	}
 	return w.remove(name, true)
+}
+
+// removeRecursive removes a recursive watch and all its sub-watches.
+func (w *kqueue) removeRecursive(name string) error {
+	paths := w.watches.removePaths(name)
+	if len(paths) == 0 {
+		return fmt.Errorf("%w: %s", ErrNonExistentWatch, name)
+	}
+	for _, p := range paths {
+		if err := w.remove(p, true); err != nil {
+			if !errors.Is(err, ErrNonExistentWatch) {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 func (w *kqueue) remove(name string, unwatchFiles bool) error {
@@ -641,6 +778,12 @@ func (w *kqueue) sendCreateIfNew(path string, fi os.FileInfo) error {
 		}
 	}
 
+	// If a new directory appears under a recursive watch, walk it and add
+	// watches for the entire subtree.
+	if fi.IsDir() && w.watches.isUnderRecurse(path) {
+		return w.addRecursiveSubdir(path)
+	}
+
 	// Like watchDirectoryFiles, but without doing another ReadDir.
 	path, err := w.internalWatch(path, fi)
 	if err != nil {
@@ -648,6 +791,54 @@ func (w *kqueue) sendCreateIfNew(path string, fi os.FileInfo) error {
 	}
 	w.watches.markSeen(path, true)
 	return nil
+}
+
+// addRecursiveSubdir adds watches for a newly created subdirectory and all
+// nested children when under a recursive watch.
+func (w *kqueue) addRecursiveSubdir(root string) error {
+	return filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() {
+			// kqueue needs per-file watches; set them up.
+			fi, err := d.Info()
+			if err != nil {
+				return err
+			}
+			cleanPath, err := w.internalWatch(path, fi)
+			if err != nil {
+				if errors.Is(err, unix.EACCES) || errors.Is(err, unix.EPERM) {
+					cleanPath = filepath.Clean(path)
+				} else {
+					return err
+				}
+			}
+			w.watches.markSeen(cleanPath, true)
+			return nil
+		}
+
+		// Add directory watch.
+		_, err = w.addWatch(path, noteAllEvents, false)
+		if err != nil {
+			return err
+		}
+
+		// Mark as recursive sub-watch.
+		w.watches.mu.Lock()
+		if fd, ok := w.watches.path[path]; ok {
+			ww := w.watches.wd[fd]
+			ww.watchFlags = flagRecurse
+			w.watches.wd[fd] = ww
+		}
+		w.watches.mu.Unlock()
+
+		// Watch files inside this directory.
+		if err := w.watchDirectoryFiles(path); err != nil {
+			return err
+		}
+		return nil
+	})
 }
 
 func (w *kqueue) internalWatch(name string, fi os.FileInfo) (string, error) {

--- a/fsnotify.go
+++ b/fsnotify.go
@@ -472,13 +472,13 @@ func withCreate() addOpt {
 	return func(opt *withOpts) { opt.sendCreate = true }
 }
 
-var enableRecurse = false
+var enableRecurse = true
 
 // Check if this path is recursive (ends with "/..." or "\..."), and return the
 // path with the /... stripped.
 func recursivePath(path string) (string, bool) {
 	path = filepath.Clean(path)
-	if !enableRecurse { // Only enabled in tests for now.
+	if !enableRecurse {
 		return path, false
 	}
 	if filepath.Base(path) == "..." {

--- a/fsnotify_test.go
+++ b/fsnotify_test.go
@@ -19,9 +19,7 @@ import (
 	"github.com/fsnotify/fsnotify/internal"
 )
 
-func init() {
-	enableRecurse = true
-}
+// enableRecurse is now true by default; no init() override needed.
 
 func TestScript(t *testing.T) {
 	err := filepath.Walk("./testdata", func(path string, info fs.FileInfo, err error) error {

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -646,7 +646,9 @@ func isSolaris() bool {
 
 func supportsRecurse(t *testing.T) {
 	switch runtime.GOOS {
-	case "windows", "linux":
+	case "windows", "linux",
+		"darwin", "freebsd", "openbsd", "netbsd", "dragonfly",
+		"solaris":
 		// Run test.
 	default:
 		t.Skip("recursion not yet supported on " + runtime.GOOS)


### PR DESCRIPTION
This PR addressed the open issues regarding the recursive watch feature.
The added tests pass for all supported systems and backends and enableRecurse is set to true.

This still needs some manual testing and a closer look as I am not experienced in golang.


