### PR TITLE
kqueue: skip broken symlinks in watchDirectoryFiles

### DIFF
--- a/backend_kqueue.go
+++ b/backend_kqueue.go
@@ -573,6 +573,12 @@ func (w *kqueue) watchDirectoryFiles(dirPath string) error {
 
 		fi, err := f.Info()
 		if err != nil {
+			// Broken symlinks (pointing to nonexistent targets) will
+			// fail here. Skip them instead of aborting the entire
+			// directory watch, so remaining files are still watched.
+			if f.Type()&os.ModeSymlink != 0 {
+				continue
+			}
 			return fmt.Errorf("%q: %w", path, err)
 		}
 


### PR DESCRIPTION
Fixes #727

## Problem

`watchDirectoryFiles` calls `DirEntry.Info()` which follows symlinks. When a symlink points to a nonexistent target, `Info()` returns an error that propagates up, aborting the entire directory watch. All files listed after the broken symlink are never watched.

## Fix

When `Info()` fails and the entry is a symlink, skip it and continue processing remaining files. This is consistent with the existing pattern for permission errors (EACCES/EPERM) which also skip the file rather than aborting.

```go
fi, err := f.Info()
if err != nil {
    if f.Type()&os.ModeSymlink != 0 {
        continue  // skip broken symlinks
    }
    return fmt.Errorf("%q: %w", path, err)
}
```