### PR TITLE
windows: fix nil pointer dereference in remWatch

### DIFF
--- a/backend_windows.go
+++ b/backend_windows.go
@@ -394,17 +394,19 @@ func (w *readDirChangesW) remWatch(pathname string) error {
 	w.mu.Lock()
 	watch := w.watches.get(ino)
 	w.mu.Unlock()
+	if watch == nil {
+		windows.CloseHandle(ino.handle)
+		return fmt.Errorf("%w: %s", ErrNonExistentWatch, pathname)
+	}
 
 	if recurse && !watch.recurse {
+		windows.CloseHandle(ino.handle)
 		return fmt.Errorf("can't use \\... with non-recursive watch %q", pathname)
 	}
 
 	err = windows.CloseHandle(ino.handle)
 	if err != nil {
 		w.sendError(os.NewSyscallError("CloseHandle", err))
-	}
-	if watch == nil {
-		return fmt.Errorf("%w: %s", ErrNonExistentWatch, pathname)
 	}
 	if pathname == dir {
 		w.sendEvent(watch.path, "", watch.mask&sysFSIGNORED)

--- a/backend_windows_test.go
+++ b/backend_windows_test.go
@@ -71,3 +71,16 @@ func TestWindowsRemWatch(t *testing.T) {
 		t.Fatal("Should be fail with closed handle\n")
 	}
 }
+
+func TestWindowsRemWatchRecurseNil(t *testing.T) {
+	tmp := t.TempDir()
+
+	w := newWatcher(t)
+	defer w.Close()
+
+	// remWatch used to dereference watch.recurse before the nil check, so
+	// calling it on an unwatched path with "...\" panicked.
+	if err := w.b.(*readDirChangesW).remWatch(tmp + `\...`); err == nil {
+		t.Fatal("expected error for non-existent watch")
+	}
+}


### PR DESCRIPTION
Fix nil pointer dereference in `remWatch` when called on a non-watched path with the `\...` recurse suffix. The nil check ran after `watch.recurse` was dereferenced; reorder the check and close the handle in the early-return paths. Includes a regression test.