### PR TITLE
bump macos-14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['macos-13', 'macos-latest']
+        os: ['macos-14', 'macos-latest']
         go: ['1.19', '1.25']
     runs-on: '${{ matrix.os }}'
     timeout-minutes: 10


### PR DESCRIPTION
macos-13 is no longer available.

- https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/

so, we need to use `macos-14`.