### PR TITLE
ci: replace macos-13 with macos-15-intel and bump Go to 1.26

### DIFF
--- a/.github/workflows/staticcheck.yml
+++ b/.github/workflows/staticcheck.yml
@@ -24,7 +24,7 @@ jobs:
             staticcheck-${{ github.ref }}
             staticcheck-refs/heads/main
       - uses: 'actions/setup-go@v5'
-        with: {go-version: '1.25'}
+        with: {go-version: '1.26'}
       - uses: 'actions/cache@v4'
         with:
           key: '${{ runner.os }}-staticcheck'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['macos-13', 'macos-latest']
+        # macos-15-intel: x86_64 coverage; macos-latest: arm64 (Apple Silicon).
+        os: ['macos-15-intel', 'macos-latest']
         go: ['1.19', '1.25']
     runs-on: '${{ matrix.os }}'
     timeout-minutes: 10

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-22.04', 'ubuntu-latest', 'ubuntu-24.04-arm']
-        go: ['1.19', '1.25']
+        go: ['1.19', '1.26']
     runs-on: '${{ matrix.os }}'
     timeout-minutes: 10
     steps:
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['windows-latest']
-        go: ['1.19', '1.25']
+        go: ['1.19', '1.26']
     runs-on: '${{ matrix.os }}'
     timeout-minutes: 10
     steps:
@@ -55,7 +55,7 @@ jobs:
       matrix:
         # macos-15-intel: x86_64 coverage; macos-latest: arm64 (Apple Silicon).
         os: ['macos-15-intel', 'macos-latest']
-        go: ['1.19', '1.25']
+        go: ['1.19', '1.26']
     runs-on: '${{ matrix.os }}'
     timeout-minutes: 10
     steps:
@@ -165,12 +165,12 @@ jobs:
       id:   'illumos'
       uses: 'vmactions/omnios-vm@v1'
       with:
-        prepare: pkg install go-125
+        prepare: pkg install go-126
         run: |
           useradd action
           export GOCACHE=/tmp/go-cache
           export GOPATH=/tmp/go-path
           su action -c 'go version'
-          FSNOTIFY_BUFFER=4096 su action -c '/opt/ooce/go-1.25/bin/go test -parallel 1    ./...'
-                               su action -c '/opt/ooce/go-1.25/bin/go test -parallel 1    ./...'
-          FSNOTIFY_DEBUG=1     su action -c '/opt/ooce/go-1.25/bin/go test -parallel 1 -v ./...'
+          FSNOTIFY_BUFFER=4096 su action -c '/opt/ooce/go-1.26/bin/go test -parallel 1    ./...'
+                               su action -c '/opt/ooce/go-1.26/bin/go test -parallel 1    ./...'
+          FSNOTIFY_DEBUG=1     su action -c '/opt/ooce/go-1.26/bin/go test -parallel 1 -v ./...'


### PR DESCRIPTION
macos-13 reached end-of-life on 2025-12-04 (https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/). Switch the Intel coverage slot to `macos-15-intel` and leave `macos-latest` as the arm64 slot. Also bump the Go upper bound of the matrix (and the illumos / staticcheck jobs) from 1.25 to 1.26.