### PR TITLE
kqueue: drop watches directly in Close() instead of going through remove()

### DIFF
--- a/backend_kqueue.go
+++ b/backend_kqueue.go
@@ -246,9 +246,22 @@ func (w *kqueue) Close() error {
 		return nil
 	}
 
+	// Snapshot and drop all watches directly. w.Remove -> w.remove
+	// short-circuits on isClosed() (which is already true after
+	// w.shared.close() above), so calling Remove here in the happy path
+	// leaked every watched directory + file descriptor. On macOS a
+	// single directory watch opens an fd for every file in the dir, so
+	// long-running processes that recreate watchers (hot-reload dev
+	// servers, etc.) ran out of fds with EMFILE (#732).
 	pathsToRemove := w.watches.listPaths(false)
 	for _, name := range pathsToRemove {
-		w.Remove(name)
+		info, ok := w.watches.byPath(name)
+		if !ok {
+			continue
+		}
+		_ = w.register([]int{info.wd}, unix.EV_DELETE, 0)
+		unix.Close(info.wd)
+		w.watches.remove(info.wd, name)
 	}
 
 	unix.Close(w.closepipe[1]) // Send "quit" message to readEvents

--- a/backend_kqueue.go
+++ b/backend_kqueue.go
@@ -257,6 +257,10 @@ func (w *kqueue) Close() error {
 	for _, name := range pathsToRemove {
 		info, ok := w.watches.byPath(name)
 		if !ok {
+			// w.path has an entry for name but w.wd doesn't --
+			// drop the stale lookup entry so the map state is
+			// consistent after Close.
+			w.watches.remove(0, name)
 			continue
 		}
 		_ = w.register([]int{info.wd}, unix.EV_DELETE, 0)

--- a/backend_kqueue_test.go
+++ b/backend_kqueue_test.go
@@ -93,3 +93,45 @@ func TestRemoveState(t *testing.T) {
 		}
 	}
 }
+
+// TestCloseClearsWatchState is a regression test for
+// https://github.com/fsnotify/fsnotify/issues/732: Close() previously
+// called w.Remove for every registered path after marking the watcher
+// closed, but remove() short-circuits on isClosed() and never closes
+// the underlying kqueue fds or drops the bookkeeping maps. Long-running
+// processes that recreate watchers hit EMFILE because every watched
+// directory and each file inside it leaked its fd on Close.
+func TestCloseClearsWatchState(t *testing.T) {
+	var (
+		tmp  = t.TempDir()
+		dir  = join(tmp, "dir")
+		file = join(dir, "file")
+	)
+	mkdir(t, dir)
+	touch(t, file)
+
+	w := newWatcher(t, tmp)
+	kq := w.b.(*kqueue)
+	addWatch(t, w, tmp)
+	addWatch(t, w, file)
+
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// After Close() every watch map should be drained. Pre-fix these
+	// stayed populated because remove() returned nil without touching
+	// the wd map.
+	if got := len(kq.watches.path); got != 0 {
+		t.Errorf("watches.path not drained after Close(): %d entries", got)
+	}
+	if got := len(kq.watches.wd); got != 0 {
+		t.Errorf("watches.wd not drained after Close(): %d entries", got)
+	}
+	if got := len(kq.watches.byUser); got != 0 {
+		t.Errorf("watches.byUser not drained after Close(): %d entries", got)
+	}
+	if got := len(kq.watches.byDir); got != 0 {
+		t.Errorf("watches.byDir not drained after Close(): %d entries", got)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #732.

`kqueue.Close()` calls `w.Remove(name)` in a loop *after* `w.shared.close()` has marked the watcher closed. `w.Remove` routes through `w.remove`, which short-circuits on `w.isClosed()` and returns nil without calling `unix.Close` on the watch fd or dropping the watches bookkeeping. Every directory watch (and each file inside it — a dir watch opens one fd per child on macOS) leaked its descriptor on `Close`, so long-running processes that recycle watchers (hot-reload dev servers, test harnesses) hit `EMFILE` after a few cycles.

## Fix

Iterate the paths directly in `Close()`: register the `EV_DELETE` kevent, `unix.Close` the fd, and drop the `watches` entry. `kqueue.remove()` is unchanged, so `Remove()` on a live watcher keeps the same semantics; only `Close()` stops leaning on it.

## Tests

Adds `TestCloseClearsWatchState` in `backend_kqueue_test.go`: creates a watcher over a temp dir + file, calls `Close`, and asserts every `watches` map is drained.

- **On master:** fails — `watches.path: 3 entries`, `watches.wd: 3 entries`, `watches.byUser: 2 entries`, `watches.byDir: 3 entries`.
- **With the fix:** passes.

`go test -count=1 ./...` green on darwin; `go vet` clean.
