### PR TITLE
windows: restore TestRemoveState

### DIFF
--- a/backend_windows_test.go
+++ b/backend_windows_test.go
@@ -9,9 +9,6 @@ import (
 )
 
 func TestRemoveState(t *testing.T) {
-	// TODO: the Windows backend is too confusing; needs some serious attention.
-	t.Skip("broken test")
-
 	var (
 		tmp  = t.TempDir()
 		dir  = join(tmp, "dir")
@@ -26,13 +23,14 @@ func TestRemoveState(t *testing.T) {
 
 	check := func(want int) {
 		t.Helper()
-		if len(w.b.(*readDirChangesW).watches) != want {
+		got := len(w.WatchList())
+		if got != want {
 			var d []string
 			for k, v := range w.b.(*readDirChangesW).watches {
 				d = append(d, fmt.Sprintf("%#v = %#v", k, v))
 			}
-			t.Errorf("unexpected number of entries in w.watches (have %d, want %d):\n%v",
-				len(w.b.(*readDirChangesW).watches), want, strings.Join(d, "\n"))
+			t.Errorf("unexpected number of watch entries (have %d, want %d):\nwatchlist=%q\ninternal=%v",
+				got, want, w.WatchList(), strings.Join(d, "\n"))
 		}
 	}
 


### PR DESCRIPTION
TestRemoveState was skipped because it counted entries in the Windows backend's top-level `watches` map, which does not match the nested structure the backend actually uses. Count watched paths via `WatchList()` instead so the assertion reflects the real number of watch entries.

Verified with `go test -run TestRemoveState -count=20 -v` on Windows.