### PR TITLE
windows: re-enable chanClosed check in TestClose/events_not_read

### DIFF
--- a/fsnotify_test.go
+++ b/fsnotify_test.go
@@ -250,11 +250,7 @@ func TestClose(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		// TODO: windows backend doesn't work well here; can't easily fix it.
-		//       Need to rewrite things a bit.
-		if runtime.GOOS != "windows" {
-			chanClosed(t, w)
-		}
+		chanClosed(t, w)
 	})
 
 	// Make sure that calling Close() while REMOVE events are emitted doesn't race.


### PR DESCRIPTION
The `chanClosed` assertion in `TestClose/events_not_read` was skipped on Windows, but the check now passes reliably. Drop the `runtime.GOOS` guard so the behaviour is exercised on Windows as well.

Verified with `go test -run 'TestClose/events_not_read' -count=20 -v` on Windows.