### PR TITLE
all: bump minimum Go version to 1.23

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-22.04', 'ubuntu-latest', 'ubuntu-24.04-arm']
-        go: ['1.19', '1.26']
+        go: ['1.23', '1.26']
     runs-on: '${{ matrix.os }}'
     timeout-minutes: 10
     steps:
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['windows-latest']
-        go: ['1.19', '1.26']
+        go: ['1.23', '1.26']
     runs-on: '${{ matrix.os }}'
     timeout-minutes: 10
     steps:
@@ -55,7 +55,7 @@ jobs:
       matrix:
         # macos-15-intel: x86_64 coverage; macos-latest: arm64 (Apple Silicon).
         os: ['macos-15-intel', 'macos-latest']
-        go: ['1.19', '1.26']
+        go: ['1.23', '1.26']
     runs-on: '${{ matrix.os }}'
     timeout-minutes: 10
     steps:

--- a/backend_windows.go
+++ b/backend_windows.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"reflect"
 	"runtime"
 	"strings"
 	"sync"
@@ -459,9 +458,8 @@ func (w *readDirChangesW) startRead(watch *watch) error {
 	}
 
 	// We need to pass the array, rather than the slice.
-	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&watch.buf))
 	rdErr := windows.ReadDirectoryChanges(watch.ino.handle,
-		(*byte)(unsafe.Pointer(hdr.Data)), uint32(hdr.Len),
+		unsafe.SliceData(watch.buf), uint32(len(watch.buf)),
 		watch.recurse, mask, nil, &watch.ov, 0)
 	if rdErr != nil {
 		err := os.NewSyscallError("ReadDirectoryChanges", rdErr)
@@ -567,12 +565,7 @@ func (w *readDirChangesW) readEvents() {
 
 			// Create a buf that is the size of the path name
 			size := int(raw.FileNameLength / 2)
-			var buf []uint16
-			// TODO: Use unsafe.Slice in Go 1.17; https://stackoverflow.com/questions/51187973
-			sh := (*reflect.SliceHeader)(unsafe.Pointer(&buf))
-			sh.Data = uintptr(unsafe.Pointer(&raw.FileName))
-			sh.Len = size
-			sh.Cap = size
+			buf := unsafe.Slice(&raw.FileName, size)
 			name := windows.UTF16ToString(buf)
 			fullname := filepath.Join(watch.path, name)
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fsnotify/fsnotify
 
-go 1.19
+go 1.23
 
 require golang.org/x/sys v0.13.0
 


### PR DESCRIPTION
Bumps the `go` directive in `go.mod` from 1.19 to 1.23 and the CI matrix likewise. `reflect.SliceHeader` has been deprecated since Go 1.21, so the two remaining uses in `backend_windows.go` are rewritten using `unsafe.Slice` / `unsafe.SliceData` (one of them already carried a `TODO: Use unsafe.Slice` comment). This also silences the staticcheck SA1019 failures that surface as soon as the go directive is bumped, which came up while looking at #723.