### PR TITLE
windows: document directory Write events and stabilize tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,14 +172,12 @@ distro's documentation):
     fs.inotify.max_user_instances=256
 
 ### Windows
-The Windows backend uses `ReadDirectoryChangesW`, which reports changes
-inside a watched directory and never reports changes to the watched
-directory itself. With a recursive watch, however, you may see `Write`
-events on intermediate directories: on an NTFS-backed volume, creating,
-renaming, or removing a child entry updates the containing directory's
-last-write time, and because the backend requests
-`FILE_NOTIFY_CHANGE_LAST_WRITE` to support `Write` on files, that update is
-surfaced as a `Write` on the directory that contains the changed entry.
+With a recursive watch, the Windows backend may emit `Write` events on
+intermediate directories: on an NTFS-backed volume, creating, renaming, or
+removing a child entry updates the containing directory's last-write time,
+and because the backend requests `FILE_NOTIFY_CHANGE_LAST_WRITE` to support
+`Write` on files, that update is surfaced as a `Write` on the directory
+that contains the changed entry.
 
 This differs from inotify, where `Write` corresponds to file-content changes
 only. kqueue has similar "directory `Write` = directory contents changed"

--- a/README.md
+++ b/README.md
@@ -172,11 +172,18 @@ distro's documentation):
     fs.inotify.max_user_instances=256
 
 ### Windows
-On Windows, when you watch a directory recursively, you may receive a
-`Write` event for an intermediate directory whenever a child entry inside
-it is created, renamed, or removed. For example, with a recursive watch on
-`/a` and a new file `/a/b/c`, you will receive `Create /a/b/c` and may
-also receive `Write /a/b`.
+Recursive watching is not currently enabled through fsnotify's public API
+(see the FAQ "Are subdirectories watched?" above). The notes below
+describe Windows backend behavior observed when recursive watching is
+enabled internally (for example, in fsnotify's own tests). They are kept
+here as a reference for maintainers and contributors who encounter the
+behavior, since the recursive code path still exists in the backend.
+
+When recursive watching is enabled and you watch a directory, you may
+receive a `Write` event for an intermediate directory whenever a child
+entry inside it is created, renamed, or removed. For example, with a
+recursive watch on `/a` and a new file `/a/b/c`, you will receive
+`Create /a/b/c` and may also receive `Write /a/b`.
 
 This happens because, on NTFS-backed volumes, modifying the entries of a
 directory updates that directory's last-write time, and the Windows

--- a/README.md
+++ b/README.md
@@ -172,20 +172,23 @@ distro's documentation):
     fs.inotify.max_user_instances=256
 
 ### Windows
-On Windows, the filesystem updates a directory's last-write time when an entry
-inside it is created, renamed, or removed. The Windows backend (built on
-`ReadDirectoryChangesW`) requests `FILE_NOTIFY_CHANGE_LAST_WRITE` to support
-`Write` events, so those directory last-write updates are reported as `Write`
-events on the parent directory.
+The Windows backend uses `ReadDirectoryChangesW`, which reports changes
+inside a watched directory and never reports changes to the watched
+directory itself. With a recursive watch, however, you may see `Write`
+events on intermediate directories: on an NTFS-backed volume, creating,
+renaming, or removing a child entry updates the containing directory's
+last-write time, and because the backend requests
+`FILE_NOTIFY_CHANGE_LAST_WRITE` to support `Write` on files, that update is
+surfaced as a `Write` on the directory that contains the changed entry.
 
-This is a deliberate, known behavior and differs from inotify, where `Write`
-corresponds to file-content changes only. It can be useful when you want to
-detect "something changed in this directory" without tracking every child
-event.
+This differs from inotify, where `Write` corresponds to file-content changes
+only. kqueue has similar "directory `Write` = directory contents changed"
+semantics, so portable code that treats `Write` on a directory as "something
+inside it changed" works on Windows and BSD/macOS but not Linux.
 
-Whether this parent-directory `Write` is observed depends on OS-level timing,
-so applications should not rely on it always appearing, nor on it never
-appearing, alongside the child events.
+Whether the directory `Write` is delivered alongside the child events is not
+guaranteed: it depends on `ReadDirectoryChangesW` buffering, NTFS metadata
+update timing, and event coalescing, none of which fsnotify controls.
 
 
 ### kqueue (macOS, all BSD systems)

--- a/README.md
+++ b/README.md
@@ -171,6 +171,22 @@ distro's documentation):
     fs.inotify.max_user_watches=200000
     fs.inotify.max_user_instances=256
 
+### Windows
+On Windows, the filesystem updates a directory's last-write time when an entry
+inside it is created, renamed, or removed. The Windows backend (built on
+`ReadDirectoryChangesW`) requests `FILE_NOTIFY_CHANGE_LAST_WRITE` to support
+`Write` events, so those directory last-write updates are reported as `Write`
+events on the parent directory.
+
+This is a deliberate, known behavior and differs from inotify, where `Write`
+corresponds to file-content changes only. It can be useful when you want to
+detect "something changed in this directory" without tracking every child
+event.
+
+Whether this parent-directory `Write` is observed depends on OS-level timing,
+so applications should not rely on it always appearing, nor on it never
+appearing, alongside the child events.
+
 
 ### kqueue (macOS, all BSD systems)
 kqueue requires opening a file descriptor for every file that's being watched;

--- a/README.md
+++ b/README.md
@@ -172,21 +172,29 @@ distro's documentation):
     fs.inotify.max_user_instances=256
 
 ### Windows
-With a recursive watch, the Windows backend may emit `Write` events on
-intermediate directories: on an NTFS-backed volume, creating, renaming, or
-removing a child entry updates the containing directory's last-write time,
-and because the backend requests `FILE_NOTIFY_CHANGE_LAST_WRITE` to support
-`Write` on files, that update is surfaced as a `Write` on the directory
-that contains the changed entry.
+On Windows, when you watch a directory recursively, you may receive a
+`Write` event for an intermediate directory whenever a child entry inside
+it is created, renamed, or removed. For example, with a recursive watch on
+`/a` and a new file `/a/b/c`, you will receive `Create /a/b/c` and may
+also receive `Write /a/b`.
 
-This differs from inotify, where `Write` corresponds to file-content changes
-only. kqueue has similar "directory `Write` = directory contents changed"
-semantics, so portable code that treats `Write` on a directory as "something
-inside it changed" works on Windows and BSD/macOS but not Linux.
+This happens because, on NTFS-backed volumes, modifying the entries of a
+directory updates that directory's last-write time, and the Windows
+backend requests `FILE_NOTIFY_CHANGE_LAST_WRITE` to support `Write` events
+on files. The same `Write` filter therefore picks up the directory's
+metadata update.
 
-Whether the directory `Write` is delivered alongside the child events is not
-guaranteed: it depends on `ReadDirectoryChangesW` buffering, NTFS metadata
-update timing, and event coalescing, none of which fsnotify controls.
+kqueue has the same "directory `Write` = directory contents changed"
+semantics, so portable code that treats `Write` on a directory as
+"something inside it changed" works on Windows and BSD/macOS, but not on
+Linux (inotify uses `Write` only for file-content changes). If you only
+care about file content, filter out `Write` events whose path refers to a
+directory.
+
+Whether the directory `Write` is actually delivered alongside the child
+events is not guaranteed: it depends on `ReadDirectoryChangesW` buffering,
+NTFS metadata update timing, and event coalescing, none of which fsnotify
+controls.
 
 
 ### kqueue (macOS, all BSD systems)

--- a/fsnotify.go
+++ b/fsnotify.go
@@ -92,11 +92,17 @@ import (
 // Sometimes it will send events for all files, sometimes it will send no
 // events, and often only for some files.
 //
-// When you watch a directory recursively, you may receive a Write event
-// for an intermediate directory whenever a child entry inside it is
-// created, renamed, or removed. For example, with a recursive watch on /a
-// and a new file /a/b/c, you will receive Create /a/b/c and may also
-// receive Write /a/b.
+// Recursive watching is not currently enabled through fsnotify's public
+// API; the recursive code path is gated and only exercised by fsnotify's
+// own tests. The note below describes backend behavior observed when
+// recursive watching is enabled internally, and is kept here as a
+// reference for maintainers and contributors who encounter it.
+//
+// When recursive watching is enabled and you watch a directory, you may
+// receive a Write event for an intermediate directory whenever a child
+// entry inside it is created, renamed, or removed. For example, with a
+// recursive watch on /a and a new file /a/b/c, you will receive
+// Create /a/b/c and may also receive Write /a/b.
 //
 // This happens because, on NTFS-backed volumes, modifying the entries of a
 // directory updates that directory's last-write time, and the Windows

--- a/fsnotify.go
+++ b/fsnotify.go
@@ -92,15 +92,16 @@ import (
 // Sometimes it will send events for all files, sometimes it will send no
 // events, and often only for some files.
 //
-// On Windows the filesystem updates a directory's last-write time when an
-// entry inside it is created, renamed, or removed. The Windows backend
-// requests FILE_NOTIFY_CHANGE_LAST_WRITE to support Write events, so those
-// directory last-write updates are reported as Write events on the parent
-// directory. This is a deliberate, known behavior and differs from inotify,
-// where Write corresponds to file-content changes only. Whether the
-// parent-directory Write is observed depends on OS-level timing, so
-// applications should not rely on it always appearing, nor on it never
-// appearing, alongside the child events.
+// ReadDirectoryChangesW reports changes inside a watched directory; it never
+// reports changes to the watched directory itself. With a recursive watch
+// you may see Write events on intermediate directories: on an NTFS-backed
+// volume, creating, renaming, or removing a child entry updates the
+// containing directory's last-write time, and because the backend requests
+// FILE_NOTIFY_CHANGE_LAST_WRITE to support Write on files, that update can
+// surface as a Write on the directory that contains the changed entry.
+// Whether such a directory Write is delivered alongside the child events is
+// not guaranteed; it depends on ReadDirectoryChangesW buffering, NTFS
+// metadata update timing, and event coalescing.
 //
 // The default ReadDirectoryChangesW() buffer size is 64K, which is the largest
 // value that is guaranteed to work with SMB filesystems. If you have many
@@ -138,13 +139,12 @@ type Watcher struct {
 	//                      want to wait until you've stopped receiving them
 	//                      (see the dedup example in cmd/fsnotify).
 	//
-	//                      Some systems may also send Write events for
-	//                      directories when the directory contents change. On
-	//                      Windows, creating, renaming, or removing an entry
-	//                      updates the parent directory's last-write time and
-	//                      is reported as a Write on the parent; this is a
-	//                      known, OS-level behavior that does not happen on
-	//                      inotify.
+	//                      Some systems also send Write events for directories
+	//                      when the directory contents change. This is the
+	//                      case for kqueue, and on Windows for the directory
+	//                      that contains a created, renamed, or removed child
+	//                      entry. It does not happen on inotify. See the
+	//                      per-platform notes on [Watcher].
 	//
 	//   fsnotify.Chmod     Attributes were changed. On Linux this is also sent
 	//                      when a file is removed (or more accurately, when a
@@ -193,10 +193,9 @@ const (
 	Create Op = 1 << iota
 
 	// The pathname was written to; this does *not* mean the write has finished,
-	// and a write can be followed by more writes. On Windows, a Write on a
-	// directory is also emitted when a child entry is created, renamed, or
-	// removed, because the filesystem updates the directory's last-write time;
-	// see the Windows notes on [Watcher].
+	// and a write can be followed by more writes. On Windows and kqueue, a
+	// Write on a directory can also indicate that its contents changed; see
+	// the per-platform notes on [Watcher].
 	Write
 
 	// The path was removed; any watches on it will be removed. Some "remove"

--- a/fsnotify.go
+++ b/fsnotify.go
@@ -92,15 +92,21 @@ import (
 // Sometimes it will send events for all files, sometimes it will send no
 // events, and often only for some files.
 //
-// With a recursive watch the Windows backend may emit Write events on
-// intermediate directories: on an NTFS-backed volume, creating, renaming,
-// or removing a child entry updates the containing directory's last-write
-// time, and because the backend requests FILE_NOTIFY_CHANGE_LAST_WRITE to
-// support Write on files, that update can surface as a Write on the
-// directory that contains the changed entry. Whether such a directory
-// Write is delivered alongside the child events is not guaranteed; it
-// depends on ReadDirectoryChangesW buffering, NTFS metadata update timing,
-// and event coalescing.
+// When you watch a directory recursively, you may receive a Write event
+// for an intermediate directory whenever a child entry inside it is
+// created, renamed, or removed. For example, with a recursive watch on /a
+// and a new file /a/b/c, you will receive Create /a/b/c and may also
+// receive Write /a/b.
+//
+// This happens because, on NTFS-backed volumes, modifying the entries of a
+// directory updates that directory's last-write time, and the Windows
+// backend requests FILE_NOTIFY_CHANGE_LAST_WRITE to support Write events
+// on files. The same Write filter therefore picks up the directory's
+// metadata update.
+//
+// Whether the directory Write is actually delivered alongside the child
+// events is not guaranteed; it depends on ReadDirectoryChangesW buffering,
+// NTFS metadata update timing, and event coalescing.
 //
 // The default ReadDirectoryChangesW() buffer size is 64K, which is the largest
 // value that is guaranteed to work with SMB filesystems. If you have many

--- a/fsnotify.go
+++ b/fsnotify.go
@@ -92,16 +92,15 @@ import (
 // Sometimes it will send events for all files, sometimes it will send no
 // events, and often only for some files.
 //
-// ReadDirectoryChangesW reports changes inside a watched directory; it never
-// reports changes to the watched directory itself. With a recursive watch
-// you may see Write events on intermediate directories: on an NTFS-backed
-// volume, creating, renaming, or removing a child entry updates the
-// containing directory's last-write time, and because the backend requests
-// FILE_NOTIFY_CHANGE_LAST_WRITE to support Write on files, that update can
-// surface as a Write on the directory that contains the changed entry.
-// Whether such a directory Write is delivered alongside the child events is
-// not guaranteed; it depends on ReadDirectoryChangesW buffering, NTFS
-// metadata update timing, and event coalescing.
+// With a recursive watch the Windows backend may emit Write events on
+// intermediate directories: on an NTFS-backed volume, creating, renaming,
+// or removing a child entry updates the containing directory's last-write
+// time, and because the backend requests FILE_NOTIFY_CHANGE_LAST_WRITE to
+// support Write on files, that update can surface as a Write on the
+// directory that contains the changed entry. Whether such a directory
+// Write is delivered alongside the child events is not guaranteed; it
+// depends on ReadDirectoryChangesW buffering, NTFS metadata update timing,
+// and event coalescing.
 //
 // The default ReadDirectoryChangesW() buffer size is 64K, which is the largest
 // value that is guaranteed to work with SMB filesystems. If you have many

--- a/fsnotify.go
+++ b/fsnotify.go
@@ -92,6 +92,16 @@ import (
 // Sometimes it will send events for all files, sometimes it will send no
 // events, and often only for some files.
 //
+// On Windows the filesystem updates a directory's last-write time when an
+// entry inside it is created, renamed, or removed. The Windows backend
+// requests FILE_NOTIFY_CHANGE_LAST_WRITE to support Write events, so those
+// directory last-write updates are reported as Write events on the parent
+// directory. This is a deliberate, known behavior and differs from inotify,
+// where Write corresponds to file-content changes only. Whether the
+// parent-directory Write is observed depends on OS-level timing, so
+// applications should not rely on it always appearing, nor on it never
+// appearing, alongside the child events.
+//
 // The default ReadDirectoryChangesW() buffer size is 64K, which is the largest
 // value that is guaranteed to work with SMB filesystems. If you have many
 // events in quick succession this may not be enough, and you will have to use
@@ -128,8 +138,13 @@ type Watcher struct {
 	//                      want to wait until you've stopped receiving them
 	//                      (see the dedup example in cmd/fsnotify).
 	//
-	//                      Some systems may send Write event for directories
-	//                      when the directory content changes.
+	//                      Some systems may also send Write events for
+	//                      directories when the directory contents change. On
+	//                      Windows, creating, renaming, or removing an entry
+	//                      updates the parent directory's last-write time and
+	//                      is reported as a Write on the parent; this is a
+	//                      known, OS-level behavior that does not happen on
+	//                      inotify.
 	//
 	//   fsnotify.Chmod     Attributes were changed. On Linux this is also sent
 	//                      when a file is removed (or more accurately, when a
@@ -178,7 +193,10 @@ const (
 	Create Op = 1 << iota
 
 	// The pathname was written to; this does *not* mean the write has finished,
-	// and a write can be followed by more writes.
+	// and a write can be followed by more writes. On Windows, a Write on a
+	// directory is also emitted when a child entry is created, renamed, or
+	// removed, because the filesystem updates the directory's last-write time;
+	// see the Windows notes on [Watcher].
 	Write
 
 	// The path was removed; any watches on it will be removed. Some "remove"

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -606,6 +606,8 @@ func cmpEvents(t *testing.T, tmp string, have, want Events) {
 	t.Helper()
 
 	have = have.TrimPrefix(tmp)
+	have = normalizeEventsForCompare(have)
+	want = normalizeEventsForCompare(want)
 
 	haveSort, wantSort := have.copy(), want.copy()
 	sort.Slice(haveSort, func(i, j int) bool {
@@ -620,6 +622,64 @@ func cmpEvents(t *testing.T, tmp string, have, want Events) {
 		b.WriteString(strings.TrimSpace(ztest.Diff(indent(haveSort), indent(wantSort))))
 		t.Errorf("\nhave:\n%s\nwant:\n%s\ndiff:\n%s", indent(have), indent(want), indent(b))
 	}
+}
+
+func normalizeEventsForCompare(events Events) Events {
+	if runtime.GOOS != "windows" {
+		return events
+	}
+
+	out := make(Events, 0, len(events))
+	for i, event := range events {
+		if event.Op == Write && hasDescendantEvent(events, i) {
+			continue
+		}
+		out = append(out, event)
+	}
+	return out
+}
+
+func hasDescendantEvent(events Events, i int) bool {
+	parent := filepath.ToSlash(events[i].Name)
+	if parent == "" {
+		return false
+	}
+	parent = strings.TrimRight(parent, "/")
+	if parent == "" {
+		parent = "/"
+	}
+
+	for j, event := range events {
+		if i == j {
+			continue
+		}
+		if isDescendantPath(parent, event.Name) || isDescendantPath(parent, event.renamedFrom) {
+			return true
+		}
+	}
+	return false
+}
+
+func isDescendantPath(parent, child string) bool {
+	if child == "" {
+		return false
+	}
+
+	parent = filepath.ToSlash(parent)
+	child = filepath.ToSlash(child)
+	parent = strings.TrimRight(parent, "/")
+	child = strings.TrimRight(child, "/")
+
+	if parent == "" {
+		parent = "/"
+	}
+	if child == "" || child == parent {
+		return false
+	}
+	if parent == "/" {
+		return strings.HasPrefix(child, "/")
+	}
+	return strings.HasPrefix(child, parent+"/")
 }
 
 func indent(s fmt.Stringer) string {


### PR DESCRIPTION
Document the Windows recursive-watch behaviour where creating, renaming, or removing a child entry on an NTFS-backed volume can surface as a `Write` on the containing directory (kqueue has the same "directory `Write` = contents changed" semantics; inotify does not).

Add a `cmpEvents` normalization that drops such directory `Write`s when a descendant event is in the same batch, so tests like `testdata/watch-recurse/rename-dir` are no longer flaky.

The normalization is interim; a follow-up will replace it with an "optional event" syntax in the testdata script format. Supersedes #739.