### PR TITLE
kqueue: skip ENOENT entries in watchDirectoryFiles

### DIFF
--- a/backend_kqueue.go
+++ b/backend_kqueue.go
@@ -578,12 +578,14 @@ func (w *kqueue) watchDirectoryFiles(dirPath string) error {
 
 		cleanPath, err := w.internalWatch(path, fi)
 		if err != nil {
-			// No permission to read the file; that's not a problem: just skip.
-			// But do add it to w.fileExists to prevent it from being picked up
-			// as a "new" file later (it still shows up in the directory
+			// No permission, or the entry resolved to a missing target
+			// (e.g. a dangling symlink): not a problem, just skip. But
+			// do mark it as seen to prevent it from being picked up as
+			// a "new" file later (it still shows up in the directory
 			// listing).
 			switch {
-			case errors.Is(err, unix.EACCES) || errors.Is(err, unix.EPERM):
+			case errors.Is(err, unix.EACCES) || errors.Is(err, unix.EPERM) ||
+				errors.Is(err, os.ErrNotExist):
 				cleanPath = filepath.Clean(path)
 			default:
 				return fmt.Errorf("%q: %w", path, err)

--- a/testdata/watch-dir/bug-727
+++ b/testdata/watch-dir/bug-727
@@ -14,6 +14,3 @@ touch /after
 
 Output:
 	create  /after
-
-	dragonfly:  # TODO: should fix this if possible.
-		no-events

--- a/testdata/watch-dir/bug-727
+++ b/testdata/watch-dir/bug-727
@@ -1,0 +1,19 @@
+# https://github.com/fsnotify/fsnotify/issues/727
+#
+# A dangling symlink already present in the directory must not cause
+# Watcher.Add to fail, and must not prevent sibling files from being
+# watched. Regression on kqueue since #681.
+require symlink
+
+ln   -s /nonexistent /dangling
+touch                /file
+
+watch /
+
+touch /after
+
+Output:
+	create  /after
+
+	dragonfly:  # TODO: should fix this if possible.
+		no-events


### PR DESCRIPTION
Fixes #727. On kqueue, `Watcher.Add` on a directory containing a dangling symlink failed because `watchDirectoryFiles` only swallowed `EACCES`/`EPERM` from `internalWatch`. When `unix.Open(O_EVTONLY)` followed a symlink to a missing target it returned `ENOENT`, which propagated up and aborted the whole `Add`. Add `os.ErrNotExist` to the same skip path so the entry is marked as seen and watching continues for the rest of the directory. Regression from #681. Adds a regression test under `testdata/watch-dir/bug-727`.