### PR TITLE
windows: lock watch field updates against concurrent WatchList

### DIFF
--- a/backend_windows.go
+++ b/backend_windows.go
@@ -358,22 +358,26 @@ func (w *readDirChangesW) addWatch(pathname string, flags uint64, bufsize int) e
 	} else {
 		windows.CloseHandle(ino.handle)
 	}
+	w.mu.Lock()
 	if pathname == dir {
 		watchEntry.mask |= flags
 	} else {
 		watchEntry.names[filepath.Base(pathname)] |= flags
 	}
+	w.mu.Unlock()
 
 	err = w.startRead(watchEntry)
 	if err != nil {
 		return err
 	}
 
+	w.mu.Lock()
 	if pathname == dir {
 		watchEntry.mask &= ^provisional
 	} else {
 		watchEntry.names[filepath.Base(pathname)] &= ^provisional
 	}
+	w.mu.Unlock()
 	return nil
 }
 
@@ -408,12 +412,18 @@ func (w *readDirChangesW) remWatch(pathname string) error {
 		w.sendError(os.NewSyscallError("CloseHandle", err))
 	}
 	if pathname == dir {
-		w.sendEvent(watch.path, "", watch.mask&sysFSIGNORED)
+		w.mu.Lock()
+		mask := watch.mask
 		watch.mask = 0
+		w.mu.Unlock()
+		w.sendEvent(watch.path, "", mask&sysFSIGNORED)
 	} else {
 		name := filepath.Base(pathname)
-		w.sendEvent(filepath.Join(watch.path, name), "", watch.names[name]&sysFSIGNORED)
+		w.mu.Lock()
+		mask := watch.names[name]
 		delete(watch.names, name)
+		w.mu.Unlock()
+		w.sendEvent(filepath.Join(watch.path, name), "", mask&sysFSIGNORED)
 	}
 
 	return w.startRead(watch)
@@ -421,17 +431,23 @@ func (w *readDirChangesW) remWatch(pathname string) error {
 
 // Must run within the I/O thread.
 func (w *readDirChangesW) deleteWatch(watch *watch) {
-	for name, mask := range watch.names {
-		if mask&provisional == 0 {
-			w.sendEvent(filepath.Join(watch.path, name), "", mask&sysFSIGNORED)
+	// Snapshot+clear under the lock so concurrent WatchList() readers see a
+	// consistent state. sendEvent must run outside the lock since it can
+	// block on the user-facing Events channel.
+	w.mu.Lock()
+	names := watch.names
+	watch.names = make(map[string]uint64)
+	mask := watch.mask
+	watch.mask = 0
+	w.mu.Unlock()
+
+	for name, m := range names {
+		if m&provisional == 0 {
+			w.sendEvent(filepath.Join(watch.path, name), "", m&sysFSIGNORED)
 		}
-		delete(watch.names, name)
 	}
-	if watch.mask != 0 {
-		if watch.mask&provisional == 0 {
-			w.sendEvent(watch.path, "", watch.mask&sysFSIGNORED)
-		}
-		watch.mask = 0
+	if mask != 0 && mask&provisional == 0 {
+		w.sendEvent(watch.path, "", mask&sysFSIGNORED)
 	}
 }
 
@@ -582,7 +598,9 @@ func (w *readDirChangesW) readEvents() {
 			case windows.FILE_ACTION_RENAMED_OLD_NAME:
 				watch.rename = name
 			case windows.FILE_ACTION_RENAMED_NEW_NAME:
-				// Update saved path of all sub-watches.
+				// Update saved path of all sub-watches and rename the
+				// names entry under the lock so WatchList() can't observe
+				// a torn state.
 				old := filepath.Join(watch.path, watch.rename)
 				w.mu.Lock()
 				for _, watchMap := range w.watches {
@@ -592,21 +610,23 @@ func (w *readDirChangesW) readEvents() {
 						}
 					}
 				}
-				w.mu.Unlock()
-
 				if watch.names[watch.rename] != 0 {
 					watch.names[name] |= watch.names[watch.rename]
 					delete(watch.names, watch.rename)
 					mask = sysFSMOVESELF
 				}
+				w.mu.Unlock()
 			}
 
 			if raw.Action != windows.FILE_ACTION_RENAMED_NEW_NAME {
 				w.sendEvent(fullname, "", watch.names[name]&mask)
 			}
 			if raw.Action == windows.FILE_ACTION_REMOVED {
-				w.sendEvent(fullname, "", watch.names[name]&sysFSIGNORED)
+				w.mu.Lock()
+				ignored := watch.names[name] & sysFSIGNORED
 				delete(watch.names, name)
+				w.mu.Unlock()
+				w.sendEvent(fullname, "", ignored)
 			}
 
 			if watch.rename != "" && raw.Action == windows.FILE_ACTION_RENAMED_NEW_NAME {

--- a/backend_windows_test.go
+++ b/backend_windows_test.go
@@ -4,6 +4,8 @@ package fsnotify
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -81,4 +83,42 @@ func TestWindowsRemWatchRecurseNil(t *testing.T) {
 	if err := w.b.(*readDirChangesW).remWatch(tmp + `\...`); err == nil {
 		t.Fatal("expected error for non-existent watch")
 	}
+}
+
+// TestWatchListRace is a regression test for
+// https://github.com/fsnotify/fsnotify/issues/709: WatchList() iterating
+// watch.names / reading watch.mask raced with the I/O thread mutating
+// the same fields from addWatch. Run with -race.
+func TestWatchListRace(t *testing.T) {
+	root := t.TempDir()
+	w := newWatcher(t)
+	defer w.Close()
+
+	addWatch(t, w, root)
+
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_ = w.WatchList()
+			}
+		}
+	}()
+
+	for i := 0; i < 50; i++ {
+		dir := filepath.Join(root, fmt.Sprintf("d%d", i))
+		if err := os.Mkdir(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.Add(dir); err != nil {
+			t.Fatal(err)
+		}
+	}
+	close(stop)
+	<-done
 }


### PR DESCRIPTION
Fixes #709. Calling `WatchList()` concurrently with `Add()`/`Remove()` on Windows raced with the I/O thread mutating `watchEntry.mask` and `watchEntry.names` outside the lock; the race detector caught the `mask` access but the more dangerous case is concurrent map iteration vs. write on `watchEntry.names`, which can panic at runtime. Hold `w.mu` around all writes to those fields (`addWatch`, `remWatch`, `deleteWatch`, and the rename/remove paths in `readEvents`). `deleteWatch` snapshots the map and mask under the lock and then calls `sendEvent` outside it to avoid blocking on the Events channel while holding the mutex. Adds `TestWatchListRace` as a regression test.