### PR TITLE
inotify: don't remove sibling watches sharing a path prefix

### DIFF
--- a/backend_inotify.go
+++ b/backend_inotify.go
@@ -82,6 +82,13 @@ func (w *watches) len() int                  { return len(w.wd) }
 func (w *watches) add(ww *watch)             { w.wd[ww.wd] = ww; w.path[ww.path] = ww.wd }
 func (w *watches) remove(watch *watch)       { delete(w.path, watch.path); delete(w.wd, watch.wd) }
 
+func isSameOrDescendantPath(path, root string) bool {
+	if path == root {
+		return true
+	}
+	return strings.HasPrefix(path, root+string(os.PathSeparator))
+}
+
 func (w *watches) removePath(path string) ([]uint32, error) {
 	path, recurse := recursivePath(path)
 	wd, ok := w.path[path]
@@ -103,7 +110,7 @@ func (w *watches) removePath(path string) ([]uint32, error) {
 	wds := make([]uint32, 0, 8)
 	wds = append(wds, wd)
 	for p, rwd := range w.path {
-		if strings.HasPrefix(p, path) {
+		if isSameOrDescendantPath(p, path) {
 			delete(w.path, p)
 			delete(w.wd, rwd)
 			wds = append(wds, rwd)

--- a/backend_inotify_test.go
+++ b/backend_inotify_test.go
@@ -5,6 +5,7 @@ package fsnotify
 import (
 	"errors"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -49,6 +50,40 @@ func TestRemoveState(t *testing.T) {
 		t.Fatal(err)
 	}
 	check(0)
+}
+
+func TestRemoveRecursiveDoesNotRemoveSiblingPrefixWatch(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	mkdir(t, tmp, "a")
+	mkdir(t, tmp, "ab")
+
+	w := newWatcher(t)
+	t.Cleanup(func() {
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	addWatch(t, w, tmp, "a", "...")
+	addWatch(t, w, tmp, "ab", "...")
+
+	have := w.WatchList()
+	slices.Sort(have)
+	want := []string{join(tmp, "a"), join(tmp, "ab")}
+	if !slices.Equal(have, want) {
+		t.Fatalf("before remove: watch list = %#v, want %#v", have, want)
+	}
+
+	if err := w.Remove(join(tmp, "a", "...")); err != nil {
+		t.Fatal(err)
+	}
+
+	have = w.WatchList()
+	if len(have) != 1 || have[0] != join(tmp, "ab") {
+		t.Fatalf("after remove: watch list = %#v, want %#v", have, []string{join(tmp, "ab")})
+	}
 }
 
 // Ensure that the correct error is returned on overflows.


### PR DESCRIPTION
`watches.removePath` used `strings.HasPrefix(p, path)` to find descendants of a recursive watch, so removing `/tmp/a/...` also dropped a sibling watch on `/tmp/ab`. Match on a path-separator boundary so only the target and its real descendants are removed.