### PR TITLE
inotify, windows: don't rename sibling watches sharing a path prefix

### DIFF
--- a/backend_inotify.go
+++ b/backend_inotify.go
@@ -508,7 +508,7 @@ func (w *inotify) handleEvent(inEvent *unix.InotifyEvent, buf *[65536]byte, offs
 					if k == watch.wd || ww.path == ev.Name {
 						continue
 					}
-					if strings.HasPrefix(ww.path, ev.renamedFrom) {
+					if isSameOrDescendantPath(ww.path, ev.renamedFrom) {
 						ww.path = strings.Replace(ww.path, ev.renamedFrom, ev.Name, 1)
 						w.watches.wd[k] = ww
 					}

--- a/backend_inotify_test.go
+++ b/backend_inotify_test.go
@@ -86,6 +86,69 @@ func TestRemoveRecursiveDoesNotRemoveSiblingPrefixWatch(t *testing.T) {
 	}
 }
 
+func TestRenameRecursiveDoesNotRenameSiblingPrefixWatch(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	mkdir(t, tmp, "a")
+	mkdir(t, tmp, "a", "sub")
+	mkdir(t, tmp, "ab")
+	mkdir(t, tmp, "ab", "sub")
+
+	w := newWatcher(t)
+	t.Cleanup(func() {
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+	})
+	go func() {
+		for range w.Events {
+		}
+	}()
+	go func() {
+		for range w.Errors {
+		}
+	}()
+
+	addWatch(t, w, tmp, "...")
+
+	have := w.WatchList()
+	slices.Sort(have)
+	want := []string{tmp, join(tmp, "a"), join(tmp, "a", "sub"), join(tmp, "ab"), join(tmp, "ab", "sub")}
+	if !slices.Equal(have, want) {
+		t.Fatalf("before rename: watch list = %#v, want %#v", have, want)
+	}
+
+	mv(t, join(tmp, "a"), tmp, "x")
+
+	// rename rewrites watch paths in the wd map directly (WatchList reads
+	// the path map, which the rewrite does not touch), so inspect the wd
+	// map paths to observe whether siblings were incorrectly renamed.
+	wdPaths := func() []string {
+		inot := w.b.(*inotify)
+		inot.mu.Lock()
+		defer inot.mu.Unlock()
+		paths := make([]string, 0, len(inot.watches.wd))
+		for _, ww := range inot.watches.wd {
+			paths = append(paths, ww.path)
+		}
+		slices.Sort(paths)
+		return paths
+	}
+
+	wantAfter := []string{tmp, join(tmp, "ab"), join(tmp, "ab", "sub"), join(tmp, "x"), join(tmp, "x", "sub")}
+	deadline := time.Now().Add(2 * time.Second)
+	var got []string
+	for time.Now().Before(deadline) {
+		got = wdPaths()
+		if slices.Equal(got, wantAfter) {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("after rename: wd paths = %#v, want %#v", got, wantAfter)
+}
+
 // Ensure that the correct error is returned on overflows.
 func TestInotifyOverflow(t *testing.T) {
 	t.Parallel()

--- a/backend_windows.go
+++ b/backend_windows.go
@@ -36,6 +36,13 @@ type readDirChangesW struct {
 
 var defaultBufferSize = 50
 
+func isSameOrDescendantPath(path, root string) bool {
+	if path == root {
+		return true
+	}
+	return strings.HasPrefix(path, root+string(os.PathSeparator))
+}
+
 func newBackend(ev chan Event, errs chan error) (backend, error) {
 	port, err := windows.CreateIoCompletionPort(windows.InvalidHandle, 0, 0, 0)
 	if err != nil {
@@ -605,7 +612,7 @@ func (w *readDirChangesW) readEvents() {
 				w.mu.Lock()
 				for _, watchMap := range w.watches {
 					for _, ww := range watchMap {
-						if strings.HasPrefix(ww.path, old) {
+						if isSameOrDescendantPath(ww.path, old) {
 							ww.path = filepath.Join(fullname, strings.TrimPrefix(ww.path, old))
 						}
 					}


### PR DESCRIPTION
The recursive rename path-rewriting loops used `strings.HasPrefix(ww.path, old)` to decide which watches belong under a renamed directory, so renaming `/tmp/a` to `/tmp/x` also rewrote a sibling watch on `/tmp/ab` to `/tmp/xb` (and on Windows, `C:\root\a` → `C:\root\x` rewrote `C:\root\ab` to `C:\root\xb`). Subsequent events were then misrouted. Match on a path-separator boundary so only the renamed directory and its real descendants are rewritten.

Stacked on top of #754 (which fixes the same shape of bug in `removePath`); merging that one first will simplify the diff.