### PR TITLE
Add "repeat" test command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,8 @@ functionally identical. End-of-line escapes with `\` are not supported.
                         #             permissions on Windows).
                         #   mkfifo    Platform doesn't support FIFO named sockets.
                         #   mknod     Platform doesn't support device nodes.
+    repeat n            # Run this test n times; useful for testing low-probability test failures.
+                        # Tests abort on the first failure.
 
     watchlist number    # Assert watchlist length.
     watchlist p1 p2     # Assert watchlist contents (unordered space-separated list).

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,13 +1,13 @@
 package fsnotify
 
 import (
+	"cmp"
 	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
 	"slices"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -604,12 +604,8 @@ func cmpEvents(t *testing.T, tmp string, have, want Events) {
 	have = have.TrimPrefix(tmp)
 
 	haveSort, wantSort := have.copy(), want.copy()
-	sort.Slice(haveSort, func(i, j int) bool {
-		return haveSort[i].String() > haveSort[j].String()
-	})
-	sort.Slice(wantSort, func(i, j int) bool {
-		return wantSort[i].String() > wantSort[j].String()
-	})
+	slices.SortFunc(haveSort, func(a, b Event) int { return cmp.Compare(a.String(), b.String()) })
+	slices.SortFunc(wantSort, func(a, b Event) int { return cmp.Compare(a.String(), b.String()) })
 
 	if haveSort.String() != wantSort.String() {
 		b := new(strings.Builder)
@@ -746,8 +742,8 @@ func parseScript(t *testing.T, in string) {
 	}
 
 	var (
-		do      = make([]func(), 0, len(cmds))
-		w       = newCollector(t)
+		repeat  = 1
+		do      = make([]func(*Watcher), 0, len(cmds))
 		mustArg = func(c command, n int) {
 			if len(c.args) != n {
 				t.Fatalf("line %d: %q requires exactly %d argument (have %d: %q)",
@@ -765,6 +761,17 @@ loop:
 	for _, c := range cmds {
 		//fmt.Printf("line %d: %q  %q\n", c.line, c.cmd, c.args)
 		switch c.cmd {
+		case "repeat":
+			mustArg(c, 1)
+			n, err := strconv.ParseInt(c.args[0], 10, 0)
+			if err != nil {
+				t.Fatalf("line %d: %s", c.line, err)
+			}
+			if n == 0 {
+				t.Fatalf("line %d: repeat must be higher than 0", c.line)
+			}
+			repeat = int(n)
+
 		case "skip", "require":
 			mustArg(c, 1)
 			switch c.args[0] {
@@ -832,19 +839,19 @@ loop:
 			}
 		case "state":
 			mustArg(c, 0)
-			do = append(do, func() {
+			do = append(do, func(w *Watcher) {
 				eventSeparator()
 				fmt.Fprintln(os.Stderr)
-				w.w.b.(interface{ state() }).state()
+				w.b.(interface{ state() }).state()
 				fmt.Fprintln(os.Stderr)
 			})
 		case "debug":
 			mustArg(c, 1)
 			switch c.args[0] {
 			case "1", "on", "true", "yes":
-				do = append(do, func() { debug = true })
+				do = append(do, func(w *Watcher) { debug = true })
 			case "0", "off", "false", "no":
-				do = append(do, func() { debug = false })
+				do = append(do, func(w *Watcher) { debug = false })
 			default:
 				t.Fatalf("line %d: unknown debug: %q", c.line, c.args[0])
 			}
@@ -854,7 +861,7 @@ loop:
 		case "watch":
 			atleastArg(c, 1)
 			if len(c.args) == 1 {
-				do = append(do, func() { addWatch(t, w.w, tmppath(tmp, c.args[0])) })
+				do = append(do, func(w *Watcher) { addWatch(t, w, tmppath(tmp, c.args[0])) })
 				continue
 			}
 
@@ -885,31 +892,31 @@ loop:
 					op |= xUnportableCloseRead
 				}
 			}
-			do = append(do, func() {
+			do = append(do, func(w *Watcher) {
 				p := tmppath(tmp, c.args[0])
-				err := w.w.AddWith(p, withOps(op))
+				err := w.AddWith(p, withOps(op))
 				if err != nil {
 					t.Fatalf("line %d: addWatch(%q): %s", c.line+1, p, err)
 				}
 			})
 		case "print":
-			do = append(do, func() { fmt.Println(strings.Join(c.args, " ")) })
+			do = append(do, func(w *Watcher) { fmt.Println(strings.Join(c.args, " ")) })
 		case "unwatch":
 			mustArg(c, 1)
-			do = append(do, func() { rmWatch(t, w.w, tmppath(tmp, c.args[0])) })
+			do = append(do, func(w *Watcher) { rmWatch(t, w, tmppath(tmp, c.args[0])) })
 		case "watchlist":
 			atleastArg(c, 1)
 			n, err := strconv.ParseInt(c.args[0], 10, 0)
 			if err == nil { // Assert length
-				do = append(do, func() {
-					wl := w.w.WatchList()
+				do = append(do, func(w *Watcher) {
+					wl := w.WatchList()
 					if l := int64(len(wl)); l != n {
 						t.Errorf("line %d: watchlist has %d entries, not %d\n%q", c.line, l, n, wl)
 					}
 				})
 			} else { // Assert contents
-				do = append(do, func() {
-					have := w.w.WatchList()
+				do = append(do, func(w *Watcher) {
+					have := w.WatchList()
 					for i := range c.args {
 						c.args[i] = tmppath(tmp, c.args[i])
 					}
@@ -924,7 +931,7 @@ loop:
 			}
 		case "touch":
 			mustArg(c, 1)
-			do = append(do, func() { touch(t, tmppath(tmp, c.args[0])) })
+			do = append(do, func(w *Watcher) { touch(t, tmppath(tmp, c.args[0])) })
 		case "mkdir":
 			recur := false
 			if len(c.args) == 2 && c.args[0] == "-p" {
@@ -932,29 +939,29 @@ loop:
 			}
 			mustArg(c, 1)
 			if recur {
-				do = append(do, func() { mkdirAll(t, tmppath(tmp, c.args[0])) })
+				do = append(do, func(w *Watcher) { mkdirAll(t, tmppath(tmp, c.args[0])) })
 			} else {
-				do = append(do, func() { mkdir(t, tmppath(tmp, c.args[0])) })
+				do = append(do, func(w *Watcher) { mkdir(t, tmppath(tmp, c.args[0])) })
 			}
 		case "ln":
 			mustArg(c, 3)
 			if c.args[0] != "-s" {
 				t.Fatalf("line %d: only ln -s is supported", c.line)
 			}
-			do = append(do, func() { symlink(t, tmppath(tmp, c.args[1]), tmppath(tmp, c.args[2])) })
+			do = append(do, func(w *Watcher) { symlink(t, tmppath(tmp, c.args[1]), tmppath(tmp, c.args[2])) })
 		case "mkfifo":
 			mustArg(c, 1)
-			do = append(do, func() { mkfifo(t, tmppath(tmp, c.args[0])) })
+			do = append(do, func(w *Watcher) { mkfifo(t, tmppath(tmp, c.args[0])) })
 		case "mknod":
 			mustArg(c, 2)
 			n, err := strconv.ParseInt(c.args[0], 10, 0)
 			if err != nil {
 				t.Fatalf("line %d: %s", c.line, err)
 			}
-			do = append(do, func() { mknod(t, int(n), tmppath(tmp, c.args[1])) })
+			do = append(do, func(w *Watcher) { mknod(t, int(n), tmppath(tmp, c.args[1])) })
 		case "mv":
 			mustArg(c, 2)
-			do = append(do, func() { mv(t, tmppath(tmp, c.args[0]), tmppath(tmp, c.args[1])) })
+			do = append(do, func(w *Watcher) { mv(t, tmppath(tmp, c.args[0]), tmppath(tmp, c.args[1])) })
 		case "rm":
 			recur := false
 			if len(c.args) == 2 && c.args[0] == "-r" {
@@ -962,9 +969,9 @@ loop:
 			}
 			mustArg(c, 1)
 			if recur {
-				do = append(do, func() { rmAll(t, tmppath(tmp, c.args[0])) })
+				do = append(do, func(w *Watcher) { rmAll(t, tmppath(tmp, c.args[0])) })
 			} else {
-				do = append(do, func() { rm(t, tmppath(tmp, c.args[0])) })
+				do = append(do, func(w *Watcher) { rm(t, tmppath(tmp, c.args[0])) })
 			}
 		case "chmod":
 			mustArg(c, 2)
@@ -972,10 +979,10 @@ loop:
 			if err != nil {
 				t.Fatalf("line %d: %s", c.line, err)
 			}
-			do = append(do, func() { chmod(t, fs.FileMode(n), tmppath(tmp, c.args[1])) })
+			do = append(do, func(w *Watcher) { chmod(t, fs.FileMode(n), tmppath(tmp, c.args[1])) })
 		case "cat":
 			mustArg(c, 1)
-			do = append(do, func() { cat(t, tmppath(tmp, c.args[0])) })
+			do = append(do, func(w *Watcher) { cat(t, tmppath(tmp, c.args[0])) })
 		case "echo":
 			if len(c.args) < 2 || len(c.args) > 3 {
 				t.Fatalf("line %d: %q requires 2 or 3 arguments (have %d: %q)",
@@ -994,9 +1001,9 @@ loop:
 
 			switch op {
 			case ">":
-				do = append(do, func() { echoTrunc(t, data, tmppath(tmp, dst)) })
+				do = append(do, func(w *Watcher) { echoTrunc(t, data, tmppath(tmp, dst)) })
 			case ">>":
-				do = append(do, func() { echoAppend(t, data, tmppath(tmp, dst)) })
+				do = append(do, func(w *Watcher) { echoAppend(t, data, tmppath(tmp, dst)) })
 			default:
 				t.Fatalf("line %d: echo requires > (truncate) or >> (append): echo data >file", c.line)
 			}
@@ -1006,16 +1013,31 @@ loop:
 			if err != nil {
 				t.Fatalf("line %d: %s", c.line, err)
 			}
-			do = append(do, func() { time.Sleep(time.Duration(n) * time.Millisecond) })
+			do = append(do, func(w *Watcher) { time.Sleep(time.Duration(n) * time.Millisecond) })
 		default:
 			t.Errorf("line %d: unknown command %q", c.line, c.cmd)
 		}
 	}
 
-	w.collect(t)
-	for _, d := range do {
-		d()
+	run := func(t *testing.T) {
+		w := newCollector(t)
+
+		w.collect(t)
+		for _, d := range do {
+			d(w.w)
+		}
+		ev := w.stop(t)
+		cmpEvents(t, tmp, ev, newEvents(t, want))
 	}
-	ev := w.stop(t)
-	cmpEvents(t, tmp, ev, newEvents(t, want))
+
+	if repeat == 1 {
+		run(t)
+	} else {
+		for i := range repeat {
+			t.Run(fmt.Sprintf("#%02d", i), run)
+			if t.Failed() {
+				break
+			}
+		}
+	}
 }


### PR DESCRIPTION
Useful for some of the flaky tests; I noticed that some tests are somewhat flaky on my laptop – not sure if that's a new thing due to changes on Linux or fsnotify, or if it was always like that. But I don't recall these failing before and I spent a lot of time eliminating flaky tests in the past 🤔

Not using it anywhere yet, useful for later.

	% uname -a
	Linux x13.arp242.net 6.19.13_1 #1 SMP PREEMPT_DYNAMIC Fri Apr 24 01:14:51 UTC 2026 x86_64 GNU/Linux

	% repeat 5; go test
	PASS
	ok      github.com/fsnotify/fsnotify    9.804s
	PASS
	ok      github.com/fsnotify/fsnotify    10.293s
	--- FAIL: TestScript (0.00s)
	    --- FAIL: TestScript/watch-dir/watch-file-inside-watched-dir (0.70s)
		helpers_test.go:1030:
		    have:
			CREATE   /file
			WRITE    /file
			CHMOD    /file
			REMOVE   /file
		    want:
			CREATE   /file
			WRITE    /file
			WRITE    /file
			CHMOD    /file
			REMOVE   /file
		    diff:
			--- have
			+++ want
			@@ -2,3 +2,4 @@
				CREATE   /file
				REMOVE   /file
				WRITE    /file
			+want   WRITE    /file
	    --- FAIL: TestScript/watch-dir/only-remove (1.51s)
		helpers_test.go:1030:
		    have:

		    want:
			REMOVE   /file
			REMOVE   /link
			REMOVE   /dir
		    diff:
			--- have
			+++ want
			@@ -1 +1,3 @@
			-have
			+want REMOVE   /dir
			+want   REMOVE   /file
			+want   REMOVE   /link
	FAIL
	exit status 1
	FAIL    github.com/fsnotify/fsnotify    9.826s
	PASS
	ok      github.com/fsnotify/fsnotify    9.984s
	--- FAIL: TestScript (0.00s)
	    --- FAIL: TestScript/watch-dir/watch-dir-inside-watched (0.86s)
		helpers_test.go:1030:
		    have:
			CREATE   /dir
			CREATE   /dir/two
			WRITE    /dir/two
			REMOVE   /dir/two
		    want:
			CREATE   /dir
			CREATE   /one
			WRITE    /one
			CREATE   /dir/two
			WRITE    /dir/two
			REMOVE   /one
			REMOVE   /dir/two
		    diff:
			--- have
			+++ want
			@@ -1,4 +1,7 @@
			      CREATE   /dir
				CREATE   /dir/two
			+want   CREATE   /one
				REMOVE   /dir/two
			+want   REMOVE   /one
				WRITE    /dir/two
			+want   WRITE    /one
	FAIL
	exit status 1
	FAIL    github.com/fsnotify/fsnotify    9.586s