### PR TITLE
Document events once only

### DIFF
--- a/fsnotify.go
+++ b/fsnotify.go
@@ -96,41 +96,8 @@ type Watcher struct {
 
 	// Events sends the filesystem change events.
 	//
-	// fsnotify can send the following events; a "path" here can refer to a
-	// file, directory, symbolic link, or special file like a FIFO.
-	//
-	//   fsnotify.Create    A new path was created; this may be followed by one
-	//                      or more Write events if data also gets written to a
-	//                      file.
-	//
-	//   fsnotify.Remove    A path was removed.
-	//
-	//   fsnotify.Rename    A path was renamed. A rename is always sent with the
-	//                      old path as Event.Name, and a Create event will be
-	//                      sent with the new name. Renames are only sent for
-	//                      paths that are currently watched; e.g. moving an
-	//                      unmonitored file into a monitored directory will
-	//                      show up as just a Create. Similarly, renaming a file
-	//                      to outside a monitored directory will show up as
-	//                      only a Rename.
-	//
-	//   fsnotify.Write     A file or named pipe was written to. A Truncate will
-	//                      also trigger a Write. A single "write action"
-	//                      initiated by the user may show up as one or multiple
-	//                      writes, depending on when the system syncs things to
-	//                      disk. For example when compiling a large Go program
-	//                      you may get hundreds of Write events, and you may
-	//                      want to wait until you've stopped receiving them
-	//                      (see the dedup example in cmd/fsnotify).
-	//
-	//                      Some systems also send Write events for directories
-	//                      when the directory contents changes.
-	//
-	//   fsnotify.Chmod     Attributes were changed. On Linux this is also sent
-	//                      when a file is removed (or more accurately, when a
-	//                      link to an inode is removed). On kqueue it's sent
-	//                      when a file is truncated. On Windows it's never
-	//                      sent.
+	// fsnotify can send Create, Remove, Rename, Write, or Chmod events. See the
+	// documentation on them for details.
 	Events chan Event
 
 	// Errors sends any errors.
@@ -169,23 +136,34 @@ type Op uint32
 // The operations fsnotify can trigger; see the documentation on [Watcher] for a
 // full description, and check them with [Event.Has].
 const (
-	// A new pathname was created.
+	// A new path was created; this may be followed by one or more [Write]
+	// events if data also gets written to a file.
 	Create Op = 1 << iota
 
-	// The pathname was written to; this does *not* mean the write has finished,
-	// and a write can be followed by more writes.
+	// A file or named pipe was written to. A Truncate will also trigger a
+	// Write. A single "write action" initiated by the user may show up as one
+	// or multiple writes, depending on when the system syncs things to disk.
+	// For example when compiling a large Go program you may get hundreds of
+	// Write events, and you may want to wait until you've stopped receiving
+	// them (see the dedup example in cmd/fsnotify).
 	Write
 
 	// The path was removed; any watches on it will be removed. Some "remove"
-	// operations may trigger a Rename if the file is actually moved (for
-	// example "remove to trash" is often a rename).
+	// operations may trigger a [Rename] event if the file is actually moved
+	// (for example "remove to trash" is often a rename).
 	Remove
 
-	// The path was renamed to something else; any watches on it will be
-	// removed.
+	// A path was renamed. A rename is always sent with the old path as
+	// Event.Name, and a [Create] event will be sent with the new name. Renames
+	// are only sent for paths that are currently watched; e.g. moving an
+	// unmonitored file into a monitored directory will show up as just a
+	// Create. Similarly, renaming a file to outside a monitored directory will
+	// show up as only a Rename.
 	Rename
 
-	// File attributes were changed.
+	// Attributes were changed. On Linux this is also sent when a file is
+	// removed (or more accurately, when a link to an inode is removed). On
+	// kqueue it's sent when a file is truncated. On Windows it's never sent.
 	//
 	// It's generally not recommended to take action on this event, as it may
 	// get triggered very frequently by some software. For example, Spotlight


### PR DESCRIPTION
They were documented both on the Events fields and on the constant, and they slightly differed. Only one is needed.