### PR TITLE
Update golang.org/x/sys

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/fsnotify/fsnotify
 
-go 1.23
+go 1.23.0
 
-require golang.org/x/sys v0.13.0
+require golang.org/x/sys v0.35.0
 
 retract (
 	v1.5.3 // Published an incorrect branch accidentally https://github.com/fsnotify/fsnotify/issues/445

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
-golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.35.0 h1:vz1N37gP5bs89s7He8XuIYXpyY0+QlsKmzipCbUtyxI=
+golang.org/x/sys v0.35.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=


### PR DESCRIPTION
Previously it was 0.13 because that was the latest version that supported Go 1.19. Since that has now been updated to Go 1.23, use the latest version that supports Go 1.23.