### PR TITLE
fix: nil Watcher doesn't panic on Add/Remove/Close

### DIFF
--- a/fsnotify.go
+++ b/fsnotify.go
@@ -283,7 +283,12 @@ func NewBufferedWatcher(sz uint) (*Watcher, error) {
 //
 // Watch the parent directory and use Event.Name to filter out files you're not
 // interested in. There is an example of this in cmd/fsnotify/file.go.
-func (w *Watcher) Add(path string) error { return w.b.Add(path) }
+func (w *Watcher) Add(path string) error {
+	if w == nil {
+		return errors.New("fsnotify: nil Watcher")
+	}
+	return w.b.Add(path)
+}
 
 // AddWith is like [Watcher.Add], but allows adding options. When using Add()
 // the defaults described below are used.
@@ -292,7 +297,12 @@ func (w *Watcher) Add(path string) error { return w.b.Add(path) }
 //
 //   - [WithBufferSize] sets the buffer size for the Windows backend; no-op on
 //     other platforms. The default is 64K (65536 bytes).
-func (w *Watcher) AddWith(path string, opts ...addOpt) error { return w.b.AddWith(path, opts...) }
+func (w *Watcher) AddWith(path string, opts ...addOpt) error {
+	if w == nil {
+		return errors.New("fsnotify: nil Watcher")
+	}
+	return w.b.AddWith(path, opts...)
+}
 
 // Remove stops monitoring the path for changes.
 //
@@ -302,17 +312,32 @@ func (w *Watcher) AddWith(path string, opts ...addOpt) error { return w.b.AddWit
 // Removing a path that has not yet been added returns [ErrNonExistentWatch].
 //
 // Returns nil if [Watcher.Close] was called.
-func (w *Watcher) Remove(path string) error { return w.b.Remove(path) }
+func (w *Watcher) Remove(path string) error {
+	if w == nil {
+		return errors.New("fsnotify: nil Watcher")
+	}
+	return w.b.Remove(path)
+}
 
 // Close removes all watches and closes the Events channel.
-func (w *Watcher) Close() error { return w.b.Close() }
+func (w *Watcher) Close() error {
+	if w == nil {
+		return nil
+	}
+	return w.b.Close()
+}
 
 // WatchList returns all paths explicitly added with [Watcher.Add] (and are not
 // yet removed).
 //
 // The order is undefined, and may differ per call. Returns nil if
 // [Watcher.Close] was called.
-func (w *Watcher) WatchList() []string { return w.b.WatchList() }
+func (w *Watcher) WatchList() []string {
+	if w == nil {
+		return nil
+	}
+	return w.b.WatchList()
+}
 
 // Supports reports if all the listed operations are supported by this platform.
 //

--- a/nil_watcher_test.go
+++ b/nil_watcher_test.go
@@ -1,0 +1,19 @@
+package fsnotify
+
+import "testing"
+
+func TestNilWatcher(t *testing.T) {
+	var w *Watcher
+	if err := w.Add("x"); err == nil {
+		t.Fatal("Add want error")
+	}
+	if err := w.Remove("x"); err == nil {
+		t.Fatal("Remove want error")
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if w.WatchList() != nil {
+		t.Fatal("WatchList want nil")
+	}
+}


### PR DESCRIPTION
```go
var w *fsnotify.Watcher
w.Add("/tmp") // panic
```

Return an error (or nil for Close/WatchList) instead.