### PR TITLE
windows: don't close a torn-down watch's handle twice

### DIFF
--- a/backend_windows.go
+++ b/backend_windows.go
@@ -80,7 +80,12 @@ func (w *readDirChangesW) sendError(err error) bool {
 		return true
 	}
 	select {
-	case <-w.done:
+	case ch := <-w.done:
+		// Put the token back, the way sendEvent does. It is Close's only handshake
+		// with the reader: swallowing it here leaves Close blocked forever on a
+		// reply that can never come, while the reader parks in
+		// GetQueuedCompletionStatus having already consumed the wakeup.
+		w.done <- ch
 		return false
 	case w.Errors <- err:
 		return true
@@ -540,6 +545,22 @@ func (w *readDirChangesW) readEvents() {
 				}
 			default:
 			}
+			continue
+		}
+
+		// Drop completions for a watch that is no longer registered. remWatch may
+		// have torn this watch down between the read completing and us dequeuing
+		// it: its handle is closed and it is out of w.watches, but the completion
+		// packet queued earlier still carries its address. Falling through would
+		// re-arm it below and close that handle a SECOND time -- and Windows may
+		// have already reissued the value. In a Go program the most frequent taker
+		// is the runtime itself (CreateEvent per new M in semacreate), so the stray
+		// close destroys a handle the runtime believes it owns and the next
+		// semasleep/semawakeup/netpoll on it dies with ERROR_INVALID_HANDLE.
+		w.mu.Lock()
+		live := w.watches.get(watch.ino) == watch
+		w.mu.Unlock()
+		if !live {
 			continue
 		}
 


### PR DESCRIPTION
Fixes #768, where the diagnosis and the measurements live.

Two changes to `backend_windows.go`.

**1. Drop completions for a watch that is no longer registered.**

`readEvents` re-arms the watch unconditionally at the end of the event loop, but `watch` is recovered from the completion packet's `OVERLAPPED` pointer and that packet may predate a `remWatch` that already closed its handle and dropped it from `w.watches`. The re-arm then runs `startRead` on a dead watch: `CancelIo` fails on the closed handle, `deleteWatch` zeroes the mask, and `CloseHandle` runs a second time on the same handle.

Windows reissues a closed handle's numeric value to the next caller. In a Go program the most frequent caller is the runtime itself — `CreateEvent` per new M in `semacreate` — so the stray close destroys a handle the runtime believes it owns, and the next `WaitForSingleObject`/`SetEvent`/netpoll on it aborts the whole process with `ERROR_INVALID_HANDLE`, from a stack pointing nowhere near fsnotify.

The check goes before the `switch qErr` so it covers the `ERROR_ACCESS_DENIED` branch too, which also calls `deleteWatch` + `startRead`. Identity comparison (`== watch`) rather than a presence test, so a *new* watch for the same directory — same volume and file index — does not make a stale packet look live.

**2. Put `Close`'s handshake token back in `sendError`.**

`w.done` has capacity 1 and carries the reply channel that is `Close`'s only handshake with the reader. `sendEvent` receives it and puts it back; `sendError` received it and dropped it. An error reported while a `Close` is in flight therefore lost the token: the reader fell through to `default`, parked in `GetQueuedCompletionStatus` having already consumed the wakeup, and `Close` blocked forever on a reply that could never come — leaking the reader thread and its handles.

The two are linked: the double close is what makes `CancelIo` fail, which is what calls `sendError`, which is what loses the token. Fixing only the first would make the second much rarer without removing it.

**Measured** on windows/arm64 (Go 1.26.5), 150 rounds of repeated `Add`/`Remove` of one directory that another goroutine writes to every 1 ms, against a build that routes every `CloseHandle` through a tracker:

| | before | after |
|---|---|---|
| double closes | 2404 | **0** |
| hung `Close`s per 200 watcher rounds | 4 | **0** |
| process handle count | slow upward drift | flat |

In the downstream application that surfaced this, the Go runtime fatal reproduced within 3 test iterations before and did not appear in 160 runs after.

Builds for windows, linux and darwin; `gofmt` clean. I could not run the Windows test suite on this arm64 box beyond the targeted reproduction, so a CI run on windows/amd64 is worth having before merge.