### PR TITLE
Expose close-write watch support

### DIFF
--- a/backend_fen.go
+++ b/backend_fen.go
@@ -462,7 +462,7 @@ func (w *fen) WatchList() []string {
 
 func (w *fen) xSupports(op Op) bool {
 	if op.Has(xUnportableOpen) || op.Has(xUnportableRead) ||
-		op.Has(xUnportableCloseWrite) || op.Has(xUnportableCloseRead) {
+		op.Has(UnportableCloseWrite) || op.Has(xUnportableCloseRead) {
 		return false
 	}
 	return true

--- a/backend_inotify.go
+++ b/backend_inotify.go
@@ -221,7 +221,7 @@ func (w *inotify) AddWith(path string, opts ...addOpt) error {
 		if with.op.Has(xUnportableRead) {
 			flags |= unix.IN_ACCESS
 		}
-		if with.op.Has(xUnportableCloseWrite) {
+		if with.op.Has(UnportableCloseWrite) {
 			flags |= unix.IN_CLOSE_WRITE
 		}
 		if with.op.Has(xUnportableCloseRead) {
@@ -547,7 +547,7 @@ func (w *inotify) newEvent(name string, mask, cookie uint32) Event {
 		e.Op |= xUnportableRead
 	}
 	if mask&unix.IN_CLOSE_WRITE == unix.IN_CLOSE_WRITE {
-		e.Op |= xUnportableCloseWrite
+		e.Op |= UnportableCloseWrite
 	}
 	if mask&unix.IN_CLOSE_NOWRITE == unix.IN_CLOSE_NOWRITE {
 		e.Op |= xUnportableCloseRead

--- a/backend_kqueue.go
+++ b/backend_kqueue.go
@@ -712,7 +712,7 @@ func (w *kqueue) xSupports(op Op) bool {
 	//	return true // Supports everything.
 	//}
 	if op.Has(xUnportableOpen) || op.Has(xUnportableRead) ||
-		op.Has(xUnportableCloseWrite) || op.Has(xUnportableCloseRead) {
+		op.Has(UnportableCloseWrite) || op.Has(xUnportableCloseRead) {
 		return false
 	}
 	return true

--- a/backend_windows.go
+++ b/backend_windows.go
@@ -695,7 +695,7 @@ func (w *readDirChangesW) toFSnotifyFlags(action uint32) uint64 {
 
 func (w *readDirChangesW) xSupports(op Op) bool {
 	if op.Has(xUnportableOpen) || op.Has(xUnportableRead) ||
-		op.Has(xUnportableCloseWrite) || op.Has(xUnportableCloseRead) {
+		op.Has(UnportableCloseWrite) || op.Has(xUnportableCloseRead) {
 		return false
 	}
 	return true

--- a/closewrite_linux_test.go
+++ b/closewrite_linux_test.go
@@ -1,0 +1,64 @@
+//go:build linux
+
+package fsnotify_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+func TestCloseWriteAfterChildWriterCloses(t *testing.T) {
+	t.Parallel()
+
+	w, err := fsnotify.NewWatcher()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()
+
+	dir := t.TempDir()
+	if !w.Supports(fsnotify.UnportableCloseWrite) {
+		t.Fatal("close-write support unavailable on Linux")
+	}
+	if err := w.AddWith(dir, fsnotify.WithOps(fsnotify.UnportableCloseWrite)); err != nil {
+		t.Fatal(err)
+	}
+
+	path := filepath.Join(dir, "file")
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := file.WriteString("content"); err != nil {
+		file.Close()
+		t.Fatal(err)
+	}
+
+	select {
+	case event := <-w.Events:
+		file.Close()
+		t.Fatalf("event arrived before writer closed: %s", event)
+	case err := <-w.Errors:
+		file.Close()
+		t.Fatal(err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case event := <-w.Events:
+		if event.Name != path || !event.Has(fsnotify.UnportableCloseWrite) {
+			t.Fatalf("event = %s, want CLOSE_WRITE for %q", event, path)
+		}
+	case err := <-w.Errors:
+		t.Fatal(err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for close-write event")
+	}
+}

--- a/closewrite_test.go
+++ b/closewrite_test.go
@@ -1,0 +1,21 @@
+package fsnotify_test
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+func TestCloseWriteCapabilityMatchesBackend(t *testing.T) {
+	w, err := fsnotify.NewWatcher()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()
+
+	want := runtime.GOOS == "linux" || runtime.GOOS == "android"
+	if got := w.Supports(fsnotify.UnportableCloseWrite); got != want {
+		t.Fatalf("Supports(UnportableCloseWrite) = %t, want %t on %s", got, want, runtime.GOOS)
+	}
+}

--- a/fsnotify.go
+++ b/fsnotify.go
@@ -235,15 +235,15 @@ const (
 	// Only works on Linux and FreeBSD.
 	xUnportableRead
 
-	// File opened for writing was closed.
+	// UnportableCloseWrite is emitted when a file opened for writing is closed.
 	//
-	// Only works on Linux and FreeBSD.
+	// Only works on Linux and Android.
 	//
 	// The advantage of using this over Write is that it's more reliable than
 	// waiting for Write events to stop. It's also faster (if you're not
 	// listening to Write events): copying a file of a few GB can easily
 	// generate tens of thousands of Write events in a short span of time.
-	xUnportableCloseWrite
+	UnportableCloseWrite
 
 	// File opened for reading was closed.
 	//
@@ -269,8 +269,8 @@ var (
 	//  - kqueue, fen:  Not used.
 	ErrEventOverflow = errors.New("fsnotify: queue or buffer overflow")
 
-	// ErrUnsupported is returned by AddWith() when WithOps() specified an
-	// Unportable event that's not supported on this platform.
+	// xErrUnsupported is returned by AddWith() when WithOps() specified an
+	// unportable event that's not supported on this platform.
 	//lint:ignore ST1012 not relevant
 	xErrUnsupported = errors.New("fsnotify: not supported with this backend")
 )
@@ -347,6 +347,7 @@ func (w *Watcher) Add(path string) error { return w.b.Add(path) }
 //
 //   - [WithBufferSize] sets the buffer size for the Windows backend; no-op on
 //     other platforms. The default is 64K (65536 bytes).
+//   - [WithOps] sets which operations to listen for.
 func (w *Watcher) AddWith(path string, opts ...addOpt) error { return w.b.AddWith(path, opts...) }
 
 // Remove stops monitoring the path for changes.
@@ -372,8 +373,8 @@ func (w *Watcher) WatchList() []string { return w.b.WatchList() }
 // Supports reports if all the listed operations are supported by this platform.
 //
 // Create, Write, Remove, Rename, and Chmod are always supported. It can only
-// return false for an Op starting with Unportable.
-func (w *Watcher) xSupports(op Op) bool { return w.b.xSupports(op) }
+// return false for an unportable operation such as [UnportableCloseWrite].
+func (w *Watcher) Supports(op Op) bool { return w.b.xSupports(op) }
 
 func (o Op) String() string {
 	var b strings.Builder
@@ -392,7 +393,7 @@ func (o Op) String() string {
 	if o.Has(xUnportableRead) {
 		b.WriteString("|READ")
 	}
-	if o.Has(xUnportableCloseWrite) {
+	if o.Has(UnportableCloseWrite) {
 		b.WriteString("|CLOSE_WRITE")
 	}
 	if o.Has(xUnportableCloseRead) {
@@ -484,14 +485,12 @@ func WithBufferSize(bytes int) addOpt {
 // time; in some use cases there may be hundreds of thousands of useless Write
 // or Chmod operations per second.
 //
-// This can also be used to add unportable operations not supported by all
-// platforms; unportable operations all start with "Unportable":
-// [UnportableOpen], [UnportableRead], [UnportableCloseWrite], and
-// [UnportableCloseRead].
+// This can also be used to add [UnportableCloseWrite], which is not supported
+// by all platforms.
 //
 // AddWith returns an error when using an unportable operation that's not
-// supported. Use [Watcher.Support] to check for support.
-func withOps(op Op) addOpt {
+// supported. Use [Watcher.Supports] to check for support.
+func WithOps(op Op) addOpt {
 	return func(opt *withOpts) { opt.op = op }
 }
 

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -556,7 +556,7 @@ func newEvents(t *testing.T, s string) Events {
 			case "READ":
 				op |= xUnportableRead
 			case "CLOSE_WRITE":
-				op |= xUnportableCloseWrite
+				op |= UnportableCloseWrite
 			case "CLOSE_READ":
 				op |= xUnportableCloseRead
 			default:
@@ -937,14 +937,14 @@ loop:
 				case "read":
 					op |= xUnportableRead
 				case "close_write":
-					op |= xUnportableCloseWrite
+					op |= UnportableCloseWrite
 				case "close_read":
 					op |= xUnportableCloseRead
 				}
 			}
 			do = append(do, func() {
 				p := tmppath(tmp, c.args[0])
-				err := w.w.AddWith(p, withOps(op))
+				err := w.w.AddWith(p, WithOps(op))
 				if err != nil {
 					t.Fatalf("line %d: addWatch(%q): %s", c.line+1, p, err)
 				}


### PR DESCRIPTION
## Summary

- export the existing close-write operation as `UnportableCloseWrite`
- export `WithOps` and `Watcher.Supports` so callers can request it safely
- verify with a public-package Linux filesystem test that close-write is emitted only after the child writer closes
- verify the capability query matches supported backends

This is a narrow export of behavior already implemented by the inotify backend; descriptor management and event handling are unchanged.

The patch is based on v1.10.1 because a downstream consumer is pinning that exact release plus this change.
