### PR TITLE
kqueue: report replaced symlinks in watched directories

### DIFF
--- a/backend_kqueue.go
+++ b/backend_kqueue.go
@@ -38,7 +38,8 @@ type (
 	watch struct {
 		wd       int
 		name     string
-		linkName string // In case of links; name is the target, and this is the link.
+		linkName string      // In case of links; name is the target, and this is the link.
+		fileInfo os.FileInfo // Identity of the opened path; used to detect replacements.
 		isDir    bool
 		dirFlags uint32
 	}
@@ -102,12 +103,12 @@ func (w *watches) addLink(path string, fd int) {
 	w.seen[path] = struct{}{}
 }
 
-func (w *watches) add(path, linkPath string, fd int, isDir bool) {
+func (w *watches) add(path, linkPath string, fd int, fi os.FileInfo) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
 	w.path[path] = fd
-	w.wd[fd] = watch{wd: fd, name: path, linkName: linkPath, isDir: isDir}
+	w.wd[fd] = watch{wd: fd, name: path, linkName: linkPath, fileInfo: fi, isDir: fi.IsDir()}
 
 	parent := filepath.Dir(path)
 	byDir, ok := w.byDir[parent]
@@ -385,6 +386,7 @@ func (w *kqueue) addWatch(name string, flags uint32, listDir bool) (string, erro
 		if err != nil {
 			return "", err
 		}
+		info.fileInfo = fi
 		info.isDir = fi.IsDir()
 	}
 
@@ -395,7 +397,7 @@ func (w *kqueue) addWatch(name string, flags uint32, listDir bool) (string, erro
 	}
 
 	if !alreadyWatching {
-		w.watches.add(name, info.linkName, info.wd, info.isDir)
+		w.watches.add(name, info.linkName, info.wd, info.fileInfo)
 	}
 
 	// Watch the directory if it has not been watched before, or if it was
@@ -637,6 +639,17 @@ func (w *kqueue) dirChange(dir string) error {
 // Send a create event if the file isn't already being tracked, and start
 // watching this file.
 func (w *kqueue) sendCreateIfNew(path string, fi os.FileInfo) error {
+	// kqueue does not always report NOTE_DELETE when a symlink is removed.
+	// Detect a replacement at the same path from the directory scan so the old
+	// file descriptor does not suppress the Create event for the new symlink.
+	if fi.Mode()&os.ModeSymlink != 0 {
+		if old, ok := w.watches.byPath(path); ok && !os.SameFile(old.fileInfo, fi) {
+			if err := w.remove2(path, false); err != nil {
+				return err
+			}
+		}
+	}
+
 	if !w.watches.seenBefore(path) {
 		if !w.sendEvent(Event{Name: path, Op: Create}) {
 			return nil

--- a/testdata/watch-dir/recreate-symlink
+++ b/testdata/watch-dir/recreate-symlink
@@ -1,0 +1,20 @@
+# Replacing a symlink in a watched directory should report the new entry.
+require symlink
+
+mkdir -p /data/v1
+mkdir -p /data/v2
+ln -s /data/v1 /data/current
+
+watch /data
+
+rm /data/current
+ln -s /data/v2 /data/current
+
+Output:
+	remove /data/current
+	create /data/current
+
+	# kqueue does not report the symlink removal, but must still report the
+	# replacement. See https://github.com/fsnotify/fsnotify/issues/689.
+	kqueue:
+		create /data/current


### PR DESCRIPTION
Fixes #689.

The kqueue backend kept the old file descriptor and `seen` entry when a symlink was removed and recreated at the same path without a `NOTE_DELETE` event. The next directory scan therefore treated the replacement as the same entry and emitted nothing.

This records the file identity attached to each kqueue watch. If a directory scan finds a different symlink at an already watched path, it removes the stale internal watch and lets the existing create path report the replacement.

The regression test uses the repository's `testdata/watch-dir` script format and the sequence from #689.

Tests:

- `go test -run 'TestScript/watch-dir/recreate-symlink$' -count=20 -v`
- `go test -run '^TestScript/watch-dir/' -count=1 -v`
- `go test -short -parallel 1 ./...`
- `go test -short -parallel 1 -race ./...`
- `go vet ./...`

I also cross-compiled the package tests for FreeBSD, OpenBSD, NetBSD, and DragonFly BSD. I did not run those test binaries or the full non-short stress suite locally.

AI disclosure: Codex helped investigate, implement, and test this change. The commands and results above were run locally on macOS arm64.
