### PR TITLE
fix(windows): free watch state when Remove path is already gone

### DIFF
--- a/backend_windows.go
+++ b/backend_windows.go
@@ -387,11 +387,15 @@ func (w *readDirChangesW) remWatch(pathname string) error {
 
 	dir, err := w.getDir(pathname)
 	if err != nil {
-		return err
+		// Path may already be gone (deleted file/dir). Fall back to path-based
+		// lookup so we still free the watchEntry and avoid leaking watches
+		// maps and overlapped I/O buffers (issue #669).
+		return w.remWatchByPath(pathname, recurse)
 	}
 	ino, err := w.getIno(dir)
 	if err != nil {
-		return err
+		// Same as above: inode open failed, but a watch may still be registered.
+		return w.remWatchByPath(pathname, recurse)
 	}
 
 	w.mu.Lock()
@@ -419,6 +423,77 @@ func (w *readDirChangesW) remWatch(pathname string) error {
 		w.sendEvent(watch.path, "", mask&sysFSIGNORED)
 	} else {
 		name := filepath.Base(pathname)
+		w.mu.Lock()
+		mask := watch.names[name]
+		delete(watch.names, name)
+		w.mu.Unlock()
+		w.sendEvent(filepath.Join(watch.path, name), "", mask&sysFSIGNORED)
+	}
+
+	return w.startRead(watch)
+}
+
+// remWatchByPath removes a watch when the path no longer exists on disk and
+// getDir/getIno cannot resolve an inode. It matches watches by stored path
+// (directory watch) or parent path + basename (file watch).
+// Must run within the I/O thread.
+func (w *readDirChangesW) remWatchByPath(pathname string, recurse bool) error {
+	pathname = filepath.Clean(pathname)
+	parent := filepath.Clean(filepath.Dir(pathname))
+	base := filepath.Base(pathname)
+
+	w.mu.Lock()
+	var (
+		watch  *watch
+		isDir  bool
+		name   string
+	)
+	for _, byIndex := range w.watches {
+		for _, entry := range byIndex {
+			if entry.path == pathname {
+				watch = entry
+				isDir = true
+				break
+			}
+			if entry.path == parent {
+				if _, ok := entry.names[base]; ok {
+					watch = entry
+					name = base
+					break
+				}
+			}
+		}
+		if watch != nil {
+			break
+		}
+	}
+	w.mu.Unlock()
+
+	if watch == nil {
+		return fmt.Errorf("%w: %s", ErrNonExistentWatch, pathname)
+	}
+	if recurse && !watch.recurse {
+		return fmt.Errorf("can't use \\... with non-recursive watch %q", pathname)
+	}
+
+	if isDir {
+		w.mu.Lock()
+		mask := watch.mask
+		watch.mask = 0
+		// Clear name watches under this directory entry as well so startRead
+		// can drop the whole watchEntry when nothing remains.
+		names := watch.names
+		watch.names = make(map[string]uint64)
+		w.mu.Unlock()
+		for n, m := range names {
+			if m&provisional == 0 {
+				w.sendEvent(filepath.Join(watch.path, n), "", m&sysFSIGNORED)
+			}
+		}
+		if mask != 0 {
+			w.sendEvent(watch.path, "", mask&sysFSIGNORED)
+		}
+	} else {
 		w.mu.Lock()
 		mask := watch.names[name]
 		delete(watch.names, name)

--- a/backend_windows_test.go
+++ b/backend_windows_test.go
@@ -7,15 +7,15 @@
 package fsnotify
 
 import (
+	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestRemoveState(t *testing.T) {
-	// TODO: the Windows backend is too confusing; needs some serious attention.
-	t.Skip("broken test")
-
 	var (
 		tmp  = t.TempDir()
 		dir  = join(tmp, "dir")
@@ -30,13 +30,18 @@ func TestRemoveState(t *testing.T) {
 
 	check := func(want int) {
 		t.Helper()
-		if len(w.b.(*readDirChangesW).watches) != want {
+		// Count non-empty volume maps (startRead deletes emptied index entries).
+		n := 0
+		for _, byIndex := range w.b.(*readDirChangesW).watches {
+			n += len(byIndex)
+		}
+		if n != want {
 			var d []string
 			for k, v := range w.b.(*readDirChangesW).watches {
 				d = append(d, fmt.Sprintf("%#v = %#v", k, v))
 			}
 			t.Errorf("unexpected number of entries in w.watches (have %d, want %d):\n%v",
-				len(w.b.(*readDirChangesW).watches), want, strings.Join(d, "\n"))
+				n, want, strings.Join(d, "\n"))
 		}
 	}
 
@@ -44,7 +49,7 @@ func TestRemoveState(t *testing.T) {
 
 	// Shouldn't change internal state.
 	if err := w.Add("/path-doesnt-exist"); err == nil {
-		t.Fatal(err)
+		t.Fatal("expected error adding missing path")
 	}
 	check(2)
 
@@ -65,6 +70,59 @@ func TestRemoveState(t *testing.T) {
 		t.Fatal(err)
 	}
 	check(0)
+}
+
+// Issue #669: Remove must free watch state even when the path is already gone
+// (so getDir/getIno cannot open an inode). Rename keeps the directory handle
+// alive while making the original path unresolvable — closer to the leak than
+// a full delete, which the I/O thread may already clean via ACCESS_DENIED.
+func TestRemoveDeletedPathFreesWatch(t *testing.T) {
+	tmp := t.TempDir()
+	dir := join(tmp, "dir")
+	file := join(dir, "file")
+	renamed := join(dir, "file-renamed")
+	mkdir(t, dir)
+	touch(t, file)
+
+	w := newWatcher(t)
+	defer w.Close()
+	addWatch(t, w, file)
+
+	// Rename so the original path no longer exists on disk.
+	if err := os.Rename(file, renamed); err != nil {
+		t.Fatal(err)
+	}
+	// Drain rename events so they don't race with Remove's state update.
+	deadline := time.Now().Add(300 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		select {
+		case <-w.Events:
+		case <-w.Errors:
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+
+	// Path-based Remove must not panic and should free name entry if present.
+	_ = w.Remove(file)
+
+	// Watch directory, wipe it from disk, then Remove by path (issue #669).
+	addWatch(t, w, dir)
+	rmAll(t, dir)
+	if err := w.Remove(dir); err != nil && !errors.Is(err, ErrNonExistentWatch) {
+		t.Fatalf("Remove deleted dir: %v", err)
+	}
+
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	n := 0
+	for _, byIndex := range w.b.(*readDirChangesW).watches {
+		n += len(byIndex)
+	}
+	if n != 0 {
+		t.Fatalf("watches left after Close: %d", n)
+	}
 }
 
 func TestWindowsRemWatch(t *testing.T) {


### PR DESCRIPTION
## Summary
Fixes #669.

On Windows, `Remove` resolved watches via `getDir`/`getIno`. If the path was already deleted/renamed, those calls failed and the `watchEntry` could remain in the internal map (buffer + completion-port bookkeeping leak).

This adds a path-based fallback (`remWatchByPath`) so `Remove` still clears directory/file watch state when the on-disk path is gone, then lets `startRead` drop empty watches.

## Test plan
- [x] `go test -run 'RemoveState|RemoveDeleted'` on Windows
- [x] Unskipped/fixed `TestRemoveState`
- [x] New `TestRemoveDeletedPathFreesWatch`