### PR TITLE
windows: fix deadlock between Close() and Add()/Remove() (#704)

### DIFF
--- a/backend_windows.go
+++ b/backend_windows.go
@@ -32,6 +32,7 @@ type readDirChangesW struct {
 	mu      sync.Mutex // Protects access to watches, closed
 	watches watchMap   // Map of watches (key: i-number)
 	closed  bool       // Set to true when Close() is first called
+	closeCh chan struct{} // Closed (once) when Close() runs, so Add/Remove can bail out
 }
 
 var defaultBufferSize = 50
@@ -48,6 +49,7 @@ func newBackend(ev chan Event, errs chan error) (backend, error) {
 		watches: make(watchMap),
 		input:   make(chan *input, 1),
 		done:    make(chan chan<- error, 1),
+		closeCh: make(chan struct{}),
 	}
 	go w.readEvents()
 	return w, nil
@@ -94,6 +96,7 @@ func (w *readDirChangesW) Close() error {
 
 	w.mu.Lock()
 	w.closed = true
+	close(w.closeCh) // Notify any in-flight Add/Remove that we're shutting down.
 	w.mu.Unlock()
 
 	// Send "done" message to the reader goroutine
@@ -131,11 +134,24 @@ func (w *readDirChangesW) AddWith(name string, opts ...addOpt) error {
 		reply:   make(chan error),
 		bufsize: with.bufsize,
 	}
+	// Bail out if Close() is racing with this Add(): otherwise the reader
+	// goroutine may take the "done" branch and exit, orphaning this input
+	// and leaving Add() blocked forever (see issue #704).
+	select {
+	case <-w.closeCh:
+		return ErrClosed
+	default:
+	}
 	w.input <- in
 	if err := w.wakeupReader(); err != nil {
 		return err
 	}
-	return <-in.reply
+	select {
+	case err := <-in.reply:
+		return err
+	case <-w.closeCh:
+		return ErrClosed
+	}
 }
 
 func (w *readDirChangesW) Remove(name string) error {
@@ -156,7 +172,12 @@ func (w *readDirChangesW) Remove(name string) error {
 	if err := w.wakeupReader(); err != nil {
 		return err
 	}
-	return <-in.reply
+	select {
+	case err := <-in.reply:
+		return err
+	case <-w.closeCh:
+		return ErrClosed
+	}
 }
 
 func (w *readDirChangesW) WatchList() []string {

--- a/backend_windows_test.go
+++ b/backend_windows_test.go
@@ -7,9 +7,13 @@
 package fsnotify
 
 import (
+	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestRemoveState(t *testing.T) {
@@ -81,5 +85,65 @@ func TestWindowsRemWatch(t *testing.T) {
 	}
 	if err := w.b.(*readDirChangesW).remWatch(tmp); err == nil {
 		t.Fatal("Should be fail with closed handle")
+	}
+}
+
+// TestWindowsCloseAddRace reproduces https://github.com/fsnotify/fsnotify/issues/704:
+// a concurrent watcher.Close() and watcher.Add() could deadlock on Windows
+// because the reader goroutine might take the "done" branch and exit, leaving
+// the in-flight Add() blocked forever on its reply channel. After the fix, Add
+// (and Remove) bail out with ErrClosed as soon as Close() runs.
+//
+// This is racy by nature; we run it many times and fail the test if any trial
+// fails to settle (the deadlock would otherwise hang the whole test binary).
+func TestWindowsCloseAddRace(t *testing.T) {
+	for trial := 0; trial < 200; trial++ {
+		root := t.TempDir()
+
+		w, err := NewWatcher()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := w.Add(root); err != nil {
+			t.Fatal(err)
+		}
+
+		done := make(chan struct{})
+		go func() {
+			<-done
+			_ = w.Close() //nolint:errcheck
+		}()
+
+		for i := range 100 {
+			if err := os.Mkdir(filepath.Join(root, fmt.Sprintf("foo%v", i)), 0755); err != nil {
+				t.Fatal(err)
+			}
+			if i == 10 {
+				close(done)
+			}
+			// A blocked Add() would mean the deadlock is back; ErrClosed (or any
+			// other error) returned promptly is the correct, non-deadlocking path.
+			if err := w.Add(filepath.Join(root, fmt.Sprintf("foo%v", i))); err != nil {
+				if !errors.Is(err, ErrClosed) {
+					t.Logf("trial %d: Add returned %v (non-fatal)", trial, err)
+				}
+			}
+		}
+
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("trial %d: Close()/Add() race did not settle (deadlock?)", trial)
+		}
+
+		// Drain channels so the closed watcher doesn't leak goroutines/events.
+		go func() {
+			for range w.Events {
+			}
+		}()
+		go func() {
+			for range w.Errors {
+			}
+		}()
 	}
 }


### PR DESCRIPTION
## What

Fixes a deadlock on Windows between a concurrent `watcher.Close()` and `watcher.Add()` (also `Remove()`) — reported in #704.

## Root cause

The reader goroutine in `backend_windows.go` selects on both `w.done` (from `Close()`) and `w.input` (from `Add`/`Remove`). When `Close()`'s `done` signal arrives while an `Add` input is still queued, the goroutine takes the `done` branch and exits — orphaning that pending input. The caller's `AddWith`/`Remove` then blocks forever on `<-in.reply`, hanging the whole test/binary.

## Fix

Add a `closeCh` channel that `Close()` closes (under the existing `mu` lock). `AddWith` and `Remove` now `select` on `closeCh` and return `ErrClosed` instead of blocking when the watcher is shutting down. Because `close()` unblocks every waiter simultaneously, the signal is never lost and there is no double-close hazard.

## Verification

- Reproduced the hang on Windows (Go `net/http` `TestFoo` pattern from #704) before the fix: `AddWith` blocked on `backend_windows.go:138` (`<-in.reply`) until the test binary timed out.
- After the fix, the new regression test `TestWindowsCloseAddRace` runs the race 200 times and passes (~5.5s) on Windows; `Add`/`Remove` return `ErrClosed` promptly during the race instead of blocking.
- `go build ./...`, `go vet ./...` clean.
- Remaining `TestScript/watch-recurse` ordering diffs are **pre-existing** on pristine `main` on this host (verified by stashing the change) and are unrelated to this fix.

## Note on assistance

This change was prepared with AI assistance (Codex); I reproduced, diagnosed, and verified the bug and the fix locally on Windows. Happy to adjust the approach if maintainers prefer a different teardown scheme.

Closes #704