### PR TITLE
inotify: emit Remove when a watch is torn down by unmount

### DIFF
--- a/backend_inotify.go
+++ b/backend_inotify.go
@@ -441,7 +441,11 @@ func (w *inotify) handleEvent(inEvent *unix.InotifyEvent, buf *[65536]byte, offs
 		internal.Debug(name, inEvent.Mask, inEvent.Cookie)
 	}
 
-	if inEvent.Mask&unix.IN_IGNORED != 0 || inEvent.Mask&unix.IN_UNMOUNT != 0 {
+	if inEvent.Mask&unix.IN_UNMOUNT != 0 {
+		w.watches.remove(watch)
+		return Event{Name: name, Op: Remove}, true
+	}
+	if inEvent.Mask&unix.IN_IGNORED != 0 {
 		w.watches.remove(watch)
 		return Event{}, true
 	}


### PR DESCRIPTION
`IN_UNMOUNT` was treated like `IN_IGNORED`: the watch was dropped and nothing was sent. After an unmount the watcher looked idle.

Emit a `Remove` event for the watched path.

Fixes #774

## Test
`go test . -count=1`
